### PR TITLE
Auto-generate AI descriptions during matching :)

### DIFF
--- a/apps/visualizer/backend/jobs/handlers.py
+++ b/apps/visualizer/backend/jobs/handlers.py
@@ -35,6 +35,7 @@ def handle_vision_match(runner, job_id: str, metadata: dict):
             'description': config.desc_weight or 0.3,
             'vision': config.vision_weight or 0.3
         })
+        force_descriptions = metadata.get('force_descriptions', False)
 
         update_job_field(runner.db, job_id, 'metadata', {
             **metadata,
@@ -91,6 +92,8 @@ def handle_vision_match(runner, job_id: str, metadata: dict):
             # Log custom configuration
             log_callback('info', f"Configuration: threshold={custom_threshold}, model={custom_model}")
             log_callback('info', f"Weights: phash={custom_weights['phash']:.2f}, desc={custom_weights['description']:.2f}, vision={custom_weights['vision']:.2f}")
+            if force_descriptions:
+                log_callback('info', 'Force regenerate descriptions: ON')
 
             # Run cascade matching with progress callback
             stats, matches = match_dump_media(
@@ -100,7 +103,8 @@ def handle_vision_match(runner, job_id: str, metadata: dict):
                 year=year,
                 last_months=last_months,
                 progress_callback=progress_callback,
-                log_callback=log_callback
+                log_callback=log_callback,
+                force_descriptions=force_descriptions,
             )
 
             # Update Lightroom with "Posted" keyword for matched images
@@ -116,6 +120,7 @@ def handle_vision_match(runner, job_id: str, metadata: dict):
                 'processed': stats['processed'],
                 'matched': stats['matched'],
                 'skipped': stats['skipped'],
+                'descriptions_generated': stats.get('descriptions_generated', 0),
                 'lightroom_updated': lr_stats['success'],
                 'lightroom_failed': lr_stats['failed'],
                 'method': 'cascade_matching',

--- a/apps/visualizer/frontend/src/constants/strings.ts
+++ b/apps/visualizer/frontend/src/constants/strings.ts
@@ -156,6 +156,7 @@ export const ADVANCED_WEIGHT_DESC = 'Description Similarity'
 export const ADVANCED_WEIGHT_VISION = 'Vision Model'
 
 export const ADVANCED_RESET_DEFAULTS = 'Reset to defaults'
+export const ADVANCED_FORCE_DESCRIPTIONS = 'Force regenerate AI descriptions'
 export const ADVANCED_START = 'Start'
 export const ADVANCED_STARTING = 'Starting...'
 

--- a/apps/visualizer/frontend/src/pages/MatchingPage.tsx
+++ b/apps/visualizer/frontend/src/pages/MatchingPage.tsx
@@ -13,6 +13,7 @@ import {
   ADVANCED_DATE_3MONTHS,
   ADVANCED_DATE_6MONTHS,
   ADVANCED_DATE_YEAR_2026,
+  ADVANCED_FORCE_DESCRIPTIONS,
   ADVANCED_START,
   ADVANCED_STARTING,
   ADVANCED_DATE_FILTER,
@@ -84,6 +85,7 @@ export function MatchingPage() {
   const [cacheStatus, setCacheStatus] = useState<CacheStatus | null>(null);
   const [isPreparingCache, setIsPreparingCache] = useState(false);
   const [cacheJob, setCacheJob] = useState<Job | null>(null);
+  const [forceDescriptions, setForceDescriptions] = useState(false);
 
   const navigate = useNavigate();
   const { socket, connected } = useSocketStore();
@@ -229,6 +231,8 @@ export function MatchingPage() {
       },
     };
 
+    if (forceDescriptions) metadata.force_descriptions = true;
+
     if (dateFilter === '3months') metadata.last_months = 3;
     else if (dateFilter === '6months') metadata.last_months = 6;
     else if (dateFilter === '2026') metadata.year = '2026';
@@ -242,7 +246,7 @@ export function MatchingPage() {
       setIsStarting(false);
       alert(`Failed to start matching: ${err instanceof Error ? err.message : 'Unknown error'}`);
     }
-  }, [weightsError, options, dateFilter]);
+  }, [weightsError, options, dateFilter, forceDescriptions]);
 
   const startCachePreparation = useCallback(async () => {
     setIsPreparingCache(true);
@@ -393,6 +397,16 @@ export function MatchingPage() {
               {isStarting ? ADVANCED_STARTING : ADVANCED_START}
             </button>
           </div>
+
+          <label className="flex items-center gap-2 text-sm text-gray-700 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={forceDescriptions}
+              onChange={(e) => setForceDescriptions(e.target.checked)}
+              className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+            />
+            {ADVANCED_FORCE_DESCRIPTIONS}
+          </label>
 
           <AdvancedOptions
             isOpen={showAdvanced}

--- a/lightroom_tagger/core/description_service.py
+++ b/lightroom_tagger/core/description_service.py
@@ -1,0 +1,41 @@
+"""Describe matched catalog images on demand."""
+import os
+
+from lightroom_tagger.core.analyzer import describe_image, get_description_model
+from lightroom_tagger.core.database import (
+    get_image,
+    get_image_description,
+    resolve_filepath,
+    store_image_description,
+)
+
+
+def describe_matched_image(db, catalog_key: str, force: bool = False) -> bool:
+    """Generate and store a description for a catalog image if needed.
+
+    Returns True if a description was generated, False if skipped.
+    """
+    if not force and get_image_description(db, catalog_key):
+        return False
+
+    image = get_image(db, catalog_key)
+    if not image or not image.get('filepath'):
+        return False
+
+    filepath = resolve_filepath(image['filepath'])
+    if not os.path.exists(filepath):
+        return False
+
+    structured = describe_image(filepath)
+    store_image_description(db, {
+        'image_key': catalog_key,
+        'image_type': 'catalog',
+        'summary': structured.get('summary', ''),
+        'composition': structured.get('composition', {}),
+        'perspectives': structured.get('perspectives', {}),
+        'technical': structured.get('technical', {}),
+        'subjects': structured.get('subjects', []),
+        'best_perspective': structured.get('best_perspective', ''),
+        'model_used': get_description_model(),
+    })
+    return True

--- a/lightroom_tagger/core/description_service.py
+++ b/lightroom_tagger/core/description_service.py
@@ -10,10 +10,18 @@ from lightroom_tagger.core.database import (
 )
 
 
+def _description_structured_is_valid(structured: dict) -> bool:
+    """True if describe_image output is worth persisting (non-empty summary)."""
+    summary = structured.get('summary')
+    return isinstance(summary, str) and bool(summary.strip())
+
+
 def describe_matched_image(db, catalog_key: str, force: bool = False) -> bool:
     """Generate and store a description for a catalog image if needed.
 
-    Returns True if a description was generated, False if skipped.
+    Returns True if a non-empty description was stored. Returns False if
+    skipped, missing file, or describe_image produced no usable summary
+    (e.g. model failure / empty fallback) — nothing is persisted in that case.
     """
     if not force and get_image_description(db, catalog_key):
         return False
@@ -27,6 +35,9 @@ def describe_matched_image(db, catalog_key: str, force: bool = False) -> bool:
         return False
 
     structured = describe_image(filepath)
+    if not _description_structured_is_valid(structured):
+        return False
+
     store_image_description(db, {
         'image_key': catalog_key,
         'image_type': 'catalog',

--- a/lightroom_tagger/core/test_description_service.py
+++ b/lightroom_tagger/core/test_description_service.py
@@ -89,3 +89,56 @@ class TestDescribeMatchedImage:
         catalog_key = store_image(db, {'filepath': '/no/such/file.jpg', 'filename': 'file.jpg'})
         result = describe_matched_image(db, catalog_key)
         assert result is False
+
+
+class TestMatchDumpMediaDescriptions:
+    """Verify match_dump_media triggers description generation for matches."""
+
+    @patch('lightroom_tagger.scripts.match_instagram_dump.describe_matched_image')
+    @patch('lightroom_tagger.scripts.match_instagram_dump.score_candidates_with_vision')
+    @patch('lightroom_tagger.scripts.match_instagram_dump.find_candidates_by_date')
+    @patch('lightroom_tagger.scripts.match_instagram_dump.get_unprocessed_dump_media')
+    def test_generates_description_on_match(self, mock_unprocessed, mock_candidates,
+                                             mock_score, mock_describe, tmp_path):
+        from lightroom_tagger.scripts.match_instagram_dump import match_dump_media
+
+        db = _make_db(tmp_path)
+        store_image(db, {'key': 'CAT1', 'filepath': '/p/a.jpg', 'filename': 'a.jpg'})
+
+        mock_unprocessed.return_value = [{'media_key': 'IG1', 'file_path': '/ig/1.jpg', 'caption': ''}]
+        mock_candidates.return_value = [{'key': 'CAT1', 'filepath': '/p/a.jpg', 'phash': 'abc', 'description': ''}]
+        mock_score.return_value = [{'catalog_key': 'CAT1', 'total_score': 0.9, 'vision_result': 'same', 'vision_score': 0.9}]
+        mock_describe.return_value = True
+
+        with patch('lightroom_tagger.scripts.match_instagram_dump.mark_dump_media_processed'), \
+             patch('lightroom_tagger.scripts.match_instagram_dump.update_instagram_status'), \
+             patch('lightroom_tagger.scripts.match_instagram_dump.init_instagram_dump_table'), \
+             patch('lightroom_tagger.scripts.match_instagram_dump.init_catalog_table'):
+            stats, matches = match_dump_media(db)
+
+        mock_describe.assert_called_once_with(db, 'CAT1', force=False)
+        assert stats['descriptions_generated'] == 1
+
+    @patch('lightroom_tagger.scripts.match_instagram_dump.describe_matched_image')
+    @patch('lightroom_tagger.scripts.match_instagram_dump.score_candidates_with_vision')
+    @patch('lightroom_tagger.scripts.match_instagram_dump.find_candidates_by_date')
+    @patch('lightroom_tagger.scripts.match_instagram_dump.get_unprocessed_dump_media')
+    def test_passes_force_flag(self, mock_unprocessed, mock_candidates,
+                                mock_score, mock_describe, tmp_path):
+        from lightroom_tagger.scripts.match_instagram_dump import match_dump_media
+
+        db = _make_db(tmp_path)
+        store_image(db, {'key': 'CAT2', 'filepath': '/p/b.jpg', 'filename': 'b.jpg'})
+
+        mock_unprocessed.return_value = [{'media_key': 'IG2', 'file_path': '/ig/2.jpg', 'caption': ''}]
+        mock_candidates.return_value = [{'key': 'CAT2', 'filepath': '/p/b.jpg', 'phash': 'def', 'description': ''}]
+        mock_score.return_value = [{'catalog_key': 'CAT2', 'total_score': 0.85, 'vision_result': 'same', 'vision_score': 0.85}]
+        mock_describe.return_value = True
+
+        with patch('lightroom_tagger.scripts.match_instagram_dump.mark_dump_media_processed'), \
+             patch('lightroom_tagger.scripts.match_instagram_dump.update_instagram_status'), \
+             patch('lightroom_tagger.scripts.match_instagram_dump.init_instagram_dump_table'), \
+             patch('lightroom_tagger.scripts.match_instagram_dump.init_catalog_table'):
+            stats, matches = match_dump_media(db, force_descriptions=True)
+
+        mock_describe.assert_called_once_with(db, 'CAT2', force=True)

--- a/lightroom_tagger/core/test_description_service.py
+++ b/lightroom_tagger/core/test_description_service.py
@@ -90,6 +90,47 @@ class TestDescribeMatchedImage:
         result = describe_matched_image(db, catalog_key)
         assert result is False
 
+    def test_does_not_store_empty_summary(self, tmp_path):
+        from lightroom_tagger.core.description_service import describe_matched_image
+
+        db = _make_db(tmp_path)
+        filepath = str(tmp_path / 'photo.jpg')
+        open(filepath, 'w').close()
+        catalog_key = store_image(db, {'filepath': filepath, 'filename': 'photo.jpg'})
+
+        with patch('lightroom_tagger.core.description_service.describe_image') as mock_desc:
+            mock_desc.return_value = {
+                'summary': '', 'composition': {}, 'perspectives': {},
+                'technical': {}, 'subjects': [], 'best_perspective': '',
+            }
+            result = describe_matched_image(db, catalog_key)
+
+        assert result is False
+        assert get_image_description(db, catalog_key) is None
+
+    def test_force_does_not_overwrite_with_empty_summary(self, tmp_path):
+        from lightroom_tagger.core.description_service import describe_matched_image
+
+        db = _make_db(tmp_path)
+        filepath = str(tmp_path / 'photo.jpg')
+        open(filepath, 'w').close()
+        catalog_key = store_image(db, {'filepath': filepath, 'filename': 'photo.jpg'})
+        store_image_description(db, {
+            'image_key': catalog_key, 'image_type': 'catalog', 'summary': 'keep me',
+            'composition': {}, 'perspectives': {}, 'technical': {},
+            'subjects': [], 'best_perspective': 'street', 'model_used': 'old',
+        })
+
+        with patch('lightroom_tagger.core.description_service.describe_image') as mock_desc:
+            mock_desc.return_value = {
+                'summary': '   ', 'composition': {}, 'perspectives': {},
+                'technical': {}, 'subjects': [], 'best_perspective': '',
+            }
+            result = describe_matched_image(db, catalog_key, force=True)
+
+        assert result is False
+        assert get_image_description(db, catalog_key)['summary'] == 'keep me'
+
 
 class TestMatchDumpMediaDescriptions:
     """Verify match_dump_media triggers description generation for matches."""
@@ -142,3 +183,30 @@ class TestMatchDumpMediaDescriptions:
             stats, matches = match_dump_media(db, force_descriptions=True)
 
         mock_describe.assert_called_once_with(db, 'CAT2', force=True)
+
+    @patch('lightroom_tagger.scripts.match_instagram_dump.describe_matched_image')
+    @patch('lightroom_tagger.scripts.match_instagram_dump.score_candidates_with_vision')
+    @patch('lightroom_tagger.scripts.match_instagram_dump.find_candidates_by_date')
+    @patch('lightroom_tagger.scripts.match_instagram_dump.get_unprocessed_dump_media')
+    def test_description_exception_logs_without_callback(self, mock_unprocessed, mock_candidates,
+                                                           mock_score, mock_describe, tmp_path):
+        from lightroom_tagger.scripts import match_instagram_dump
+        from lightroom_tagger.scripts.match_instagram_dump import match_dump_media
+
+        db = _make_db(tmp_path)
+        store_image(db, {'key': 'CAT3', 'filepath': '/p/c.jpg', 'filename': 'c.jpg'})
+
+        mock_unprocessed.return_value = [{'media_key': 'IG3', 'file_path': '/ig/3.jpg', 'caption': ''}]
+        mock_candidates.return_value = [{'key': 'CAT3', 'filepath': '/p/c.jpg', 'phash': 'ghi', 'description': ''}]
+        mock_score.return_value = [{'catalog_key': 'CAT3', 'total_score': 0.9, 'vision_result': 'same', 'vision_score': 0.9}]
+        mock_describe.side_effect = RuntimeError('model down')
+
+        with patch('lightroom_tagger.scripts.match_instagram_dump.mark_dump_media_processed'), \
+             patch('lightroom_tagger.scripts.match_instagram_dump.update_instagram_status'), \
+             patch('lightroom_tagger.scripts.match_instagram_dump.init_instagram_dump_table'), \
+             patch('lightroom_tagger.scripts.match_instagram_dump.init_catalog_table'), \
+             patch.object(match_instagram_dump.logger, 'warning') as mock_warn:
+            match_dump_media(db, log_callback=None)
+
+        mock_warn.assert_called_once()
+        assert 'CAT3' in mock_warn.call_args[0][0]

--- a/lightroom_tagger/core/test_description_service.py
+++ b/lightroom_tagger/core/test_description_service.py
@@ -1,0 +1,91 @@
+from unittest.mock import patch
+
+from lightroom_tagger.core.database import init_database, store_image, store_image_description, get_image_description
+
+
+def _make_db(tmp_path):
+    db_path = str(tmp_path / 'test.db')
+    return init_database(db_path)
+
+
+class TestDescribeMatchedImage:
+    def test_generates_description_when_missing(self, tmp_path):
+        from lightroom_tagger.core.description_service import describe_matched_image
+
+        db = _make_db(tmp_path)
+        filepath = str(tmp_path / 'photo.jpg')
+        open(filepath, 'w').close()
+        catalog_key = store_image(db, {'filepath': filepath, 'filename': 'photo.jpg'})
+
+        with patch('lightroom_tagger.core.description_service.describe_image') as mock_desc, \
+             patch('lightroom_tagger.core.description_service.get_description_model', return_value='test-model'):
+            mock_desc.return_value = {
+                'summary': 'A street scene', 'composition': {'depth': 'shallow'},
+                'perspectives': {'street': {'score': 7}}, 'technical': {'mood': 'gritty'},
+                'subjects': ['person'], 'best_perspective': 'street',
+            }
+            result = describe_matched_image(db, catalog_key)
+
+        assert result is True
+        desc = get_image_description(db, catalog_key)
+        assert desc is not None
+        assert desc['summary'] == 'A street scene'
+
+    def test_skips_when_description_exists(self, tmp_path):
+        from lightroom_tagger.core.description_service import describe_matched_image
+
+        db = _make_db(tmp_path)
+        filepath = str(tmp_path / 'photo.jpg')
+        open(filepath, 'w').close()
+        catalog_key = store_image(db, {'filepath': filepath, 'filename': 'photo.jpg'})
+        store_image_description(db, {
+            'image_key': catalog_key, 'image_type': 'catalog', 'summary': 'existing',
+            'composition': {}, 'perspectives': {}, 'technical': {},
+            'subjects': [], 'best_perspective': 'street', 'model_used': 'old',
+        })
+
+        with patch('lightroom_tagger.core.description_service.describe_image') as mock_desc:
+            result = describe_matched_image(db, catalog_key)
+
+        assert result is False
+        mock_desc.assert_not_called()
+
+    def test_regenerates_when_force_is_true(self, tmp_path):
+        from lightroom_tagger.core.description_service import describe_matched_image
+
+        db = _make_db(tmp_path)
+        filepath = str(tmp_path / 'photo.jpg')
+        open(filepath, 'w').close()
+        catalog_key = store_image(db, {'filepath': filepath, 'filename': 'photo.jpg'})
+        store_image_description(db, {
+            'image_key': catalog_key, 'image_type': 'catalog', 'summary': 'old summary',
+            'composition': {}, 'perspectives': {}, 'technical': {},
+            'subjects': [], 'best_perspective': 'street', 'model_used': 'old',
+        })
+
+        with patch('lightroom_tagger.core.description_service.describe_image') as mock_desc, \
+             patch('lightroom_tagger.core.description_service.get_description_model', return_value='new-model'):
+            mock_desc.return_value = {
+                'summary': 'Updated summary', 'composition': {}, 'perspectives': {},
+                'technical': {}, 'subjects': [], 'best_perspective': 'documentary',
+            }
+            result = describe_matched_image(db, catalog_key, force=True)
+
+        assert result is True
+        desc = get_image_description(db, catalog_key)
+        assert desc['summary'] == 'Updated summary'
+
+    def test_returns_false_when_image_not_found(self, tmp_path):
+        from lightroom_tagger.core.description_service import describe_matched_image
+
+        db = _make_db(tmp_path)
+        result = describe_matched_image(db, 'NONEXISTENT')
+        assert result is False
+
+    def test_returns_false_when_file_missing(self, tmp_path):
+        from lightroom_tagger.core.description_service import describe_matched_image
+
+        db = _make_db(tmp_path)
+        catalog_key = store_image(db, {'filepath': '/no/such/file.jpg', 'filename': 'file.jpg'})
+        result = describe_matched_image(db, catalog_key)
+        assert result is False

--- a/lightroom_tagger/scripts/match_instagram_dump.py
+++ b/lightroom_tagger/scripts/match_instagram_dump.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
 """Match Instagram dump media against catalog images using cascade filtering."""
 
+import logging
 import os
 import sys
+
+logger = logging.getLogger(__name__)
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
@@ -133,8 +136,11 @@ def match_dump_media(db, threshold: float = 0.7, batch_size: int = None,
                 if describe_matched_image(db, matched_catalog_key, force=force_descriptions):
                     stats['descriptions_generated'] += 1
             except Exception as e:
+                msg = f'Description failed for {matched_catalog_key}: {e}'
                 if log_callback:
-                    log_callback('warning', f'Description failed for {matched_catalog_key}: {e}')
+                    log_callback('warning', msg)
+                else:
+                    logger.warning(msg)
         else:
             best = results[0] if results else None
             mark_dump_media_attempted(

--- a/lightroom_tagger/scripts/match_instagram_dump.py
+++ b/lightroom_tagger/scripts/match_instagram_dump.py
@@ -9,6 +9,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from lightroom_tagger.core.analyzer import compute_phash
 from lightroom_tagger.core.config import load_config
+from lightroom_tagger.core.description_service import describe_matched_image
 from lightroom_tagger.core.database import (
     get_instagram_by_date_filter,
     get_unprocessed_dump_media,
@@ -26,7 +27,7 @@ from lightroom_tagger.core.path_utils import resolve_catalog_path
 def match_dump_media(db, threshold: float = 0.7, batch_size: int = None,
                      month: str = None, year: str = None, last_months: int = None,
                      progress_callback=None, log_callback=None,
-                     weights: dict = None) -> tuple:
+                     weights: dict = None, force_descriptions: bool = False) -> tuple:
     """Match Instagram dump media against catalog images using cascade filtering.
 
     Args:
@@ -39,6 +40,7 @@ def match_dump_media(db, threshold: float = 0.7, batch_size: int = None,
         progress_callback: Optional callback(current, total, message) for progress updates
         log_callback: Optional callback(level, message) for detailed logging
         weights: Optional dict with 'phash', 'description', 'vision' keys for scoring weights
+        force_descriptions: If True, regenerate descriptions even when one exists
 
     Returns:
         Tuple of (stats dict, matches list)
@@ -52,6 +54,7 @@ def match_dump_media(db, threshold: float = 0.7, batch_size: int = None,
         'processed': 0,
         'matched': 0,
         'skipped': 0,
+        'descriptions_generated': 0,
     }
     matches_found = []
 
@@ -126,6 +129,12 @@ def match_dump_media(db, threshold: float = 0.7, batch_size: int = None,
 
             stats['matched'] += 1
             matches_found.append(best_match)
+            try:
+                if describe_matched_image(db, matched_catalog_key, force=force_descriptions):
+                    stats['descriptions_generated'] += 1
+            except Exception as e:
+                if log_callback:
+                    log_callback('warning', f'Description failed for {matched_catalog_key}: {e}')
         else:
             best = results[0] if results else None
             mark_dump_media_attempted(


### PR DESCRIPTION
## SUMMARY

Auto-generate AI descriptions during matching :)
When a match is confirmed, the catalog image gets an AI description automatically if it doesn't have one yet. No more running separate jobs or scripts to fill in descriptions.

## DETAILS

- New `describe_matched_image(db, key, force=False)` helper in `lightroom_tagger/core/description_service.py` — checks if description exists, resolves NAS path, calls Ollama, stores result
- Wired into `match_dump_media` right after match confirmation — description failures log a warning but don't break matching
- `force_descriptions` flag flows from UI checkbox → job metadata → handler → matcher
- New "Force regenerate AI descriptions" checkbox in the Matching trigger panel
- Job results now include `descriptions_generated` count
- 7 new tests covering: generate/skip/force/missing image/missing file + 2 integration tests

## DEVELOPER IMPACT

`match_dump_media` has a new optional `force_descriptions=False` parameter. Existing callers (CLI, other scripts) are unaffected — descriptions auto-generate by default, and force is off unless explicitly set.

## TESTING

7 tests passing:
- `TestDescribeMatchedImage` (5 unit tests for the helper)
- `TestMatchDumpMediaDescriptions` (2 integration tests for the wiring)

## DOCUMENTATION

N/A

## PIC

![descriptions go brrr](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExYnVhMGhwNjlhbWptcmQ0cTZmNXdscGR5d2RtbDB6aDcwY2FiNyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/LmNwrBhejkK9EFP504/giphy.gif)