### PR TITLE
feat: multi-provider vision system with retry, fallback, and config UI

### DIFF
--- a/apps/visualizer/backend/api/descriptions.py
+++ b/apps/visualizer/backend/api/descriptions.py
@@ -73,6 +73,7 @@ def generate_description(db, image_key):
     )
 
     old_model_env = os.environ.get('DESCRIPTION_VISION_MODEL')
+    provider_id = None
     try:
         data = request.json or {}
         image_type = data.get('image_type', 'catalog')
@@ -84,18 +85,26 @@ def generate_description(db, image_key):
         if model and not provider_id:
             os.environ['DESCRIPTION_VISION_MODEL'] = model
 
-        if image_type == 'catalog':
-            generated = describe_matched_image(
-                db, image_key, force=force,
-                provider_id=provider_id, model=provider_model,
-            )
-        elif image_type == 'instagram':
-            generated = describe_instagram_image(
-                db, image_key, force=force,
-                provider_id=provider_id, model=provider_model,
-            )
-        else:
-            return jsonify({'error': f'Invalid image_type: {image_type}'}), 400
+        try:
+            if image_type == 'catalog':
+                generated = describe_matched_image(
+                    db, image_key, force=force,
+                    provider_id=provider_id, model=provider_model,
+                )
+            elif image_type == 'instagram':
+                generated = describe_instagram_image(
+                    db, image_key, force=force,
+                    provider_id=provider_id, model=provider_model,
+                )
+            else:
+                return jsonify({'error': f'Invalid image_type: {image_type}'}), 400
+        except KeyError:
+            if not provider_id:
+                raise
+            return jsonify({
+                'error': 'invalid_provider',
+                'message': f'Unknown provider: {provider_id}',
+            }), 400
 
         if not generated:
             existing = get_image_description(db, image_key)
@@ -106,11 +115,23 @@ def generate_description(db, image_key):
         desc = get_image_description(db, image_key)
         return jsonify({'generated': True, 'description': _deserialize(desc) if desc else None})
     except RateLimitError as e:
-        return jsonify({'error': 'rate_limit', 'message': str(e), 'provider': e.provider}), 429
+        return jsonify({
+            'error': 'rate_limit',
+            'message': str(e),
+            'provider': getattr(e, 'provider', None) or provider_id,
+        }), 429
     except AuthenticationError as e:
-        return jsonify({'error': 'auth_error', 'message': str(e), 'provider': e.provider}), 401
+        return jsonify({
+            'error': 'auth_error',
+            'message': str(e),
+            'provider': getattr(e, 'provider', None) or provider_id,
+        }), 401
     except (ModelUnavailableError, ConnectionError) as e:
-        return jsonify({'error': 'provider_unavailable', 'message': str(e), 'provider': e.provider}), 503
+        return jsonify({
+            'error': 'provider_unavailable',
+            'message': str(e),
+            'provider': getattr(e, 'provider', None) or provider_id,
+        }), 503
     except Exception as e:
         return error_server_error(str(e))
     finally:

--- a/apps/visualizer/backend/api/descriptions.py
+++ b/apps/visualizer/backend/api/descriptions.py
@@ -65,20 +65,35 @@ def get_description(db, image_key):
 @with_db
 def generate_description(db, image_key):
     """Generate AI description for a single image."""
+    from lightroom_tagger.core.provider_errors import (
+        AuthenticationError,
+        ConnectionError,
+        ModelUnavailableError,
+        RateLimitError,
+    )
+
     old_model_env = os.environ.get('DESCRIPTION_VISION_MODEL')
     try:
         data = request.json or {}
         image_type = data.get('image_type', 'catalog')
         force = data.get('force', False)
         model = data.get('model')
+        provider_id = data.get('provider_id')
+        provider_model = data.get('provider_model')
 
-        if model:
+        if model and not provider_id:
             os.environ['DESCRIPTION_VISION_MODEL'] = model
 
         if image_type == 'catalog':
-            generated = describe_matched_image(db, image_key, force=force)
+            generated = describe_matched_image(
+                db, image_key, force=force,
+                provider_id=provider_id, model=provider_model,
+            )
         elif image_type == 'instagram':
-            generated = describe_instagram_image(db, image_key, force=force)
+            generated = describe_instagram_image(
+                db, image_key, force=force,
+                provider_id=provider_id, model=provider_model,
+            )
         else:
             return jsonify({'error': f'Invalid image_type: {image_type}'}), 400
 
@@ -90,6 +105,12 @@ def generate_description(db, image_key):
 
         desc = get_image_description(db, image_key)
         return jsonify({'generated': True, 'description': _deserialize(desc) if desc else None})
+    except RateLimitError as e:
+        return jsonify({'error': 'rate_limit', 'message': str(e), 'provider': e.provider}), 429
+    except AuthenticationError as e:
+        return jsonify({'error': 'auth_error', 'message': str(e), 'provider': e.provider}), 401
+    except (ModelUnavailableError, ConnectionError) as e:
+        return jsonify({'error': 'provider_unavailable', 'message': str(e), 'provider': e.provider}), 503
     except Exception as e:
         return error_server_error(str(e))
     finally:

--- a/apps/visualizer/backend/api/providers.py
+++ b/apps/visualizer/backend/api/providers.py
@@ -1,0 +1,39 @@
+"""Providers API — list providers, models, manage fallback order."""
+
+from flask import Blueprint, jsonify, request
+
+from lightroom_tagger.core.provider_registry import ProviderRegistry
+
+bp = Blueprint("providers", __name__)
+
+
+def _get_registry() -> ProviderRegistry:
+    return ProviderRegistry()
+
+
+@bp.route("/", methods=["GET"])
+def list_providers():
+    registry = _get_registry()
+    return jsonify(registry.list_providers())
+
+
+@bp.route("/<provider_id>/models", methods=["GET"])
+def list_models(provider_id: str):
+    registry = _get_registry()
+    try:
+        models = registry.list_models(provider_id)
+    except KeyError:
+        return jsonify({"error": f"Unknown provider: {provider_id}"}), 404
+    return jsonify(models)
+
+
+@bp.route("/fallback-order", methods=["GET"])
+def get_fallback_order():
+    registry = _get_registry()
+    return jsonify({"order": registry.fallback_order})
+
+
+@bp.route("/defaults", methods=["GET"])
+def get_defaults():
+    registry = _get_registry()
+    return jsonify(registry.defaults)

--- a/apps/visualizer/backend/api/providers.py
+++ b/apps/visualizer/backend/api/providers.py
@@ -1,6 +1,6 @@
 """Providers API — list providers, models, manage fallback order."""
 
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, jsonify
 
 from lightroom_tagger.core.provider_registry import ProviderRegistry
 

--- a/apps/visualizer/backend/app.py
+++ b/apps/visualizer/backend/app.py
@@ -30,10 +30,11 @@ def create_app():
     db = init_db(db_path)
     app.db = db
 
-    from api import descriptions, images, jobs, system
+    from api import descriptions, images, jobs, providers, system
     app.register_blueprint(jobs.bp, url_prefix='/api/jobs')
     app.register_blueprint(images.bp, url_prefix='/api/images')
     app.register_blueprint(descriptions.bp, url_prefix='/api/descriptions')
+    app.register_blueprint(providers.bp, url_prefix='/api/providers')
     app.register_blueprint(system.bp, url_prefix='/api')
 
     from websocket.events import register_socket_events

--- a/apps/visualizer/backend/jobs/handlers.py
+++ b/apps/visualizer/backend/jobs/handlers.py
@@ -27,7 +27,6 @@ def handle_vision_match(runner, job_id: str, metadata: dict):
         # Store config in metadata so it shows during job run
         config = load_config()
 
-        # Use custom values from metadata if provided, otherwise config defaults
         custom_model = metadata.get('vision_model', config.vision_model or 'gemma3:27b')
         custom_threshold = metadata.get('threshold', config.match_threshold or 0.7)
         custom_weights = metadata.get('weights', {
@@ -36,6 +35,8 @@ def handle_vision_match(runner, job_id: str, metadata: dict):
             'vision': config.vision_weight or 0.3
         })
         force_descriptions = metadata.get('force_descriptions', False)
+        provider_id = metadata.get('provider_id')
+        provider_model = metadata.get('provider_model')
 
         update_job_field(runner.db, job_id, 'metadata', {
             **metadata,
@@ -97,7 +98,6 @@ def handle_vision_match(runner, job_id: str, metadata: dict):
             if force_descriptions:
                 log_callback('info', 'Force regenerate descriptions: ON')
 
-            # Run cascade matching with progress callback
             stats, matches = match_dump_media(
                 db,
                 threshold=custom_threshold,
@@ -109,6 +109,8 @@ def handle_vision_match(runner, job_id: str, metadata: dict):
                 media_key=media_key,
                 force_descriptions=force_descriptions,
                 force_reprocess=force_reprocess,
+                provider_id=provider_id,
+                provider_model=provider_model,
             )
 
             # Update Lightroom with "Posted" keyword for matched images
@@ -401,6 +403,8 @@ def handle_batch_describe(runner, job_id: str, metadata: dict):
         date_filter = metadata.get('date_filter', 'all')  # all, 3months, 6months
         force = metadata.get('force', False)
         vision_model = metadata.get('vision_model')
+        desc_provider_id = metadata.get('provider_id')
+        desc_provider_model = metadata.get('provider_model')
 
         if vision_model:
             os.environ['DESCRIPTION_VISION_MODEL'] = vision_model
@@ -470,9 +474,15 @@ def handle_batch_describe(runner, job_id: str, metadata: dict):
 
             try:
                 if itype == 'catalog':
-                    result = describe_matched_image(lib_db, key, force=force)
+                    result = describe_matched_image(
+                        lib_db, key, force=force,
+                        provider_id=desc_provider_id, model=desc_provider_model,
+                    )
                 else:
-                    result = describe_instagram_image(lib_db, key, force=force)
+                    result = describe_instagram_image(
+                        lib_db, key, force=force,
+                        provider_id=desc_provider_id, model=desc_provider_model,
+                    )
 
                 if result:
                     described += 1

--- a/apps/visualizer/backend/tests/test_descriptions_api.py
+++ b/apps/visualizer/backend/tests/test_descriptions_api.py
@@ -1,8 +1,10 @@
 import json
 import os
 import tempfile
+from unittest.mock import patch
 
 from lightroom_tagger.core.database import init_database
+from lightroom_tagger.core.provider_errors import RateLimitError
 
 
 def _make_client(db_path):
@@ -130,6 +132,56 @@ def test_generate_should_reject_invalid_image_type():
         )
         assert resp.status_code == 400
         assert 'error' in resp.get_json()
+
+
+def test_generate_should_return_400_when_provider_id_unknown():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, 'test.db')
+        db = init_database(db_path)
+        db.execute(
+            "INSERT OR IGNORE INTO images (key, filename, filepath, date_taken) VALUES (?, ?, ?, ?)",
+            ('cat_001', 'photo.jpg', '/fake/photo.jpg', '2024-01-15'),
+        )
+        db.commit()
+        db.close()
+
+        client = _make_client(db_path)
+        with patch(
+            'api.descriptions.describe_matched_image',
+            side_effect=KeyError("Unknown provider: not_a_real_provider"),
+        ):
+            resp = client.post(
+                '/api/descriptions/cat_001/generate',
+                json={'image_type': 'catalog', 'provider_id': 'not_a_real_provider'},
+            )
+        assert resp.status_code == 400
+        body = resp.get_json()
+        assert body['error'] == 'invalid_provider'
+        assert 'not_a_real_provider' in body['message']
+
+
+def test_generate_should_include_request_provider_on_rate_limit_when_exception_has_no_provider():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, 'test.db')
+        db = init_database(db_path)
+        db.execute(
+            "INSERT OR IGNORE INTO images (key, filename, filepath, date_taken) VALUES (?, ?, ?, ?)",
+            ('cat_001', 'photo.jpg', '/fake/photo.jpg', '2024-01-15'),
+        )
+        db.commit()
+        db.close()
+
+        client = _make_client(db_path)
+        with patch(
+            'api.descriptions.describe_matched_image',
+            side_effect=RateLimitError('too many requests'),
+        ):
+            resp = client.post(
+                '/api/descriptions/cat_001/generate',
+                json={'image_type': 'catalog', 'provider_id': 'ollama'},
+            )
+        assert resp.status_code == 429
+        assert resp.get_json()['provider'] == 'ollama'
 
 
 def test_list_descriptions_should_paginate():

--- a/apps/visualizer/backend/tests/test_providers_api.py
+++ b/apps/visualizer/backend/tests/test_providers_api.py
@@ -1,0 +1,60 @@
+import os
+from unittest.mock import patch
+
+import pytest
+from app import create_app
+
+
+@pytest.fixture()
+def client():
+    app = create_app()
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+class TestListProviders:
+    def test_should_return_all_providers(self, client):
+        resp = client.get("/api/providers/")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        ids = [p["id"] for p in data]
+        assert "ollama" in ids
+        assert "nvidia_nim" in ids
+        assert "openrouter" in ids
+
+    def test_should_include_availability_status(self, client):
+        resp = client.get("/api/providers/")
+        data = resp.get_json()
+        provider_map = {p["id"]: p for p in data}
+        assert "available" in provider_map["ollama"]
+
+
+class TestListModels:
+    def test_should_return_models_for_nvidia(self, client):
+        resp = client.get("/api/providers/nvidia_nim/models")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        model_ids = [m["id"] for m in data]
+        assert "meta/llama-4-maverick-17b-128e-instruct" in model_ids
+
+    def test_should_return_404_for_unknown_provider(self, client):
+        resp = client.get("/api/providers/nonexistent/models")
+        assert resp.status_code == 404
+
+
+class TestFallbackOrder:
+    def test_should_return_fallback_order(self, client):
+        resp = client.get("/api/providers/fallback-order")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["order"] == ["ollama", "nvidia_nim", "openrouter"]
+
+
+class TestDefaults:
+    def test_should_return_defaults(self, client):
+        resp = client.get("/api/providers/defaults")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["vision_comparison"]["provider"] == "ollama"
+        assert data["description"]["provider"] == "ollama"

--- a/apps/visualizer/frontend/src/App.tsx
+++ b/apps/visualizer/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { DescriptionsPage } from './pages/DescriptionsPage'
 import { InstagramPage } from './pages/InstagramPage'
 import { MatchingPage } from './pages/MatchingPage'
 import { JobsPage } from './pages/JobsPage'
+import { ProvidersPage } from './pages/ProvidersPage'
 import { MatchOptionsProvider } from './stores/matchOptionsContext'
 
 function App() {
@@ -19,6 +20,7 @@ function App() {
           <Route path="matching" element={<ErrorBoundary><MatchingPage /></ErrorBoundary>} />
           <Route path="descriptions" element={<ErrorBoundary><DescriptionsPage /></ErrorBoundary>} />
           <Route path="jobs" element={<ErrorBoundary><JobsPage /></ErrorBoundary>} />
+          <Route path="providers" element={<ErrorBoundary><ProvidersPage /></ErrorBoundary>} />
         </Route>
       </Routes>
     </Router>

--- a/apps/visualizer/frontend/src/components/Layout.tsx
+++ b/apps/visualizer/frontend/src/components/Layout.tsx
@@ -1,5 +1,5 @@
 import { Outlet, NavLink } from 'react-router-dom'
-import { APP_TITLE, NAV_DASHBOARD, NAV_INSTAGRAM, NAV_MATCHING, NAV_DESCRIPTIONS, NAV_JOBS } from '../constants/strings'
+import { APP_TITLE, NAV_DASHBOARD, NAV_INSTAGRAM, NAV_MATCHING, NAV_DESCRIPTIONS, NAV_JOBS, NAV_PROVIDERS } from '../constants/strings'
 
 export function Layout() {
   const navItems = [
@@ -8,6 +8,7 @@ export function Layout() {
     { to: '/matching', label: NAV_MATCHING },
     { to: '/descriptions', label: NAV_DESCRIPTIONS },
     { to: '/jobs', label: NAV_JOBS },
+    { to: '/providers', label: NAV_PROVIDERS },
   ]
   
   return (

--- a/apps/visualizer/frontend/src/components/providers/FallbackOrderPanel.tsx
+++ b/apps/visualizer/frontend/src/components/providers/FallbackOrderPanel.tsx
@@ -1,0 +1,38 @@
+import type { Provider } from '../../services/api'
+import {
+  PROVIDER_FALLBACK_HEADING,
+  PROVIDER_FALLBACK_DESCRIPTION,
+  PROVIDER_STATUS_SUFFIX_UNAVAILABLE,
+} from '../../constants/strings'
+
+interface Props {
+  providers: Provider[]
+  order: string[]
+}
+
+export function FallbackOrderPanel({ providers, order }: Props) {
+  const providerMap = Object.fromEntries(providers.map(provider => [provider.id, provider]))
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white shadow-sm p-4">
+      <h3 className="font-semibold text-gray-900 mb-1">{PROVIDER_FALLBACK_HEADING}</h3>
+      <p className="text-sm text-gray-500 mb-3">{PROVIDER_FALLBACK_DESCRIPTION}</p>
+      <ol className="space-y-1.5">
+        {order.map((providerId, index) => {
+          const provider = providerMap[providerId]
+          return (
+            <li key={providerId} className="flex items-center gap-2 text-sm">
+              <span className="w-5 h-5 rounded-full bg-indigo-100 text-indigo-700 flex items-center justify-center text-xs font-bold">
+                {index + 1}
+              </span>
+              <span className="font-medium text-gray-800">{provider?.name ?? providerId}</span>
+              {provider && !provider.available && (
+                <span className="text-xs text-gray-400">{PROVIDER_STATUS_SUFFIX_UNAVAILABLE}</span>
+              )}
+            </li>
+          )
+        })}
+      </ol>
+    </div>
+  )
+}

--- a/apps/visualizer/frontend/src/components/providers/ProviderCard.tsx
+++ b/apps/visualizer/frontend/src/components/providers/ProviderCard.tsx
@@ -1,0 +1,88 @@
+import type { Provider, ProviderModel } from '../../services/api'
+import {
+  PROVIDER_STATUS_AVAILABLE,
+  PROVIDER_STATUS_UNAVAILABLE,
+  PROVIDER_MODELS_HEADING,
+  PROVIDER_NO_MODELS,
+  PROVIDER_COL_MODEL,
+  PROVIDER_COL_VISION,
+  PROVIDER_COL_SOURCE,
+  PROVIDER_SOURCE_CONFIG,
+  PROVIDER_SOURCE_DISCOVERED,
+  PROVIDER_SOURCE_USER,
+} from '../../constants/strings'
+
+const SOURCE_LABELS: Record<string, string> = {
+  config: PROVIDER_SOURCE_CONFIG,
+  discovered: PROVIDER_SOURCE_DISCOVERED,
+  user: PROVIDER_SOURCE_USER,
+}
+
+interface Props {
+  provider: Provider
+  models: ProviderModel[]
+  expanded: boolean
+  onToggle: () => void
+}
+
+export function ProviderCard({ provider, models, expanded, onToggle }: Props) {
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white shadow-sm">
+      <button
+        type="button"
+        onClick={onToggle}
+        className="w-full px-4 py-3 flex items-center justify-between text-left"
+      >
+        <div className="flex items-center gap-3">
+          <h3 className="font-semibold text-gray-900">{provider.name}</h3>
+          <span
+            className={`text-xs px-2 py-0.5 rounded-full font-medium ${
+              provider.available
+                ? 'bg-green-100 text-green-700'
+                : 'bg-gray-100 text-gray-500'
+            }`}
+          >
+            {provider.available ? PROVIDER_STATUS_AVAILABLE : PROVIDER_STATUS_UNAVAILABLE}
+          </span>
+        </div>
+        <span className="text-gray-400 text-sm">{expanded ? '▲' : '▼'}</span>
+      </button>
+
+      {expanded && (
+        <div className="px-4 pb-4 border-t border-gray-100 pt-3">
+          <h4 className="text-sm font-medium text-gray-700 mb-2">{PROVIDER_MODELS_HEADING}</h4>
+          {models.length === 0 ? (
+            <p className="text-sm text-gray-400">{PROVIDER_NO_MODELS}</p>
+          ) : (
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-gray-500 text-xs uppercase tracking-wider">
+                  <th className="pb-1">{PROVIDER_COL_MODEL}</th>
+                  <th className="pb-1">{PROVIDER_COL_VISION}</th>
+                  <th className="pb-1">{PROVIDER_COL_SOURCE}</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-50">
+                {models.map(model => (
+                  <tr key={model.id}>
+                    <td className="py-1.5 font-mono text-xs text-gray-800">{model.name}</td>
+                    <td className="py-1.5">
+                      {model.vision ? (
+                        <span className="text-green-600">✓</span>
+                      ) : (
+                        <span className="text-gray-300">—</span>
+                      )}
+                    </td>
+                    <td className="py-1.5 text-xs text-gray-500">
+                      {SOURCE_LABELS[model.source] ?? model.source}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/visualizer/frontend/src/components/providers/index.ts
+++ b/apps/visualizer/frontend/src/components/providers/index.ts
@@ -1,0 +1,2 @@
+export { ProviderCard } from './ProviderCard'
+export { FallbackOrderPanel } from './FallbackOrderPanel'

--- a/apps/visualizer/frontend/src/components/ui/ProviderModelSelect.tsx
+++ b/apps/visualizer/frontend/src/components/ui/ProviderModelSelect.tsx
@@ -1,0 +1,69 @@
+import { useProviders, useProviderModels } from '../../hooks/useProviders'
+import {
+  PROVIDER_SELECT_LABEL,
+  PROVIDER_MODEL_SELECT_LABEL,
+  PROVIDER_NO_MODELS,
+  PROVIDER_STATUS_SUFFIX_UNAVAILABLE,
+  PROVIDER_AUTO_DEFAULT,
+  PROVIDER_MODEL_AUTO_FIRST,
+  MSG_LOADING,
+} from '../../constants/strings'
+
+interface Props {
+  providerId: string | null
+  modelId: string | null
+  onChange: (providerId: string | null, modelId: string | null) => void
+  className?: string
+}
+
+export function ProviderModelSelect({ providerId, modelId, onChange, className = '' }: Props) {
+  const { providers } = useProviders()
+  const { models, loading: modelsLoading } = useProviderModels(providerId)
+
+  const visionModels = models.filter(model => model.vision)
+
+  return (
+    <div className={`flex gap-3 ${className}`}>
+      <label className="flex flex-col gap-1 text-sm flex-1">
+        <span className="font-medium text-gray-700">{PROVIDER_SELECT_LABEL}</span>
+        <select
+          value={providerId ?? ''}
+          onChange={event => {
+            const selectedId = event.target.value || null
+            onChange(selectedId, null)
+          }}
+          className="rounded-md border border-gray-300 px-3 py-1.5 text-sm"
+        >
+          <option value="">{PROVIDER_AUTO_DEFAULT}</option>
+          {providers.map(provider => (
+            <option key={provider.id} value={provider.id} disabled={!provider.available}>
+              {provider.name} {provider.available ? '' : PROVIDER_STATUS_SUFFIX_UNAVAILABLE}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      {providerId && (
+        <label className="flex flex-col gap-1 text-sm flex-1">
+          <span className="font-medium text-gray-700">{PROVIDER_MODEL_SELECT_LABEL}</span>
+          <select
+            value={modelId ?? ''}
+            onChange={event => onChange(providerId, event.target.value || null)}
+            className="rounded-md border border-gray-300 px-3 py-1.5 text-sm"
+            disabled={modelsLoading}
+          >
+            <option value="">{modelsLoading ? MSG_LOADING : PROVIDER_MODEL_AUTO_FIRST}</option>
+            {visionModels.length === 0 && !modelsLoading && (
+              <option disabled>{PROVIDER_NO_MODELS}</option>
+            )}
+            {visionModels.map(model => (
+              <option key={model.id} value={model.id}>
+                {model.name}
+              </option>
+            ))}
+          </select>
+        </label>
+      )}
+    </div>
+  )
+}

--- a/apps/visualizer/frontend/src/constants/strings.ts
+++ b/apps/visualizer/frontend/src/constants/strings.ts
@@ -288,3 +288,36 @@ export const MODAL_MATCH_RESULT_NONE = 'No match found'
 export const MODAL_MATCH_VIEW_RESULTS = 'View on Matching page'
 export const MODAL_MATCH_RETRY = 'Run Again'
 export const MODAL_MATCH_JOB_FAILED_PREFIX = 'Match failed:'
+
+// Providers Page
+export const NAV_PROVIDERS = 'Providers'
+export const PROVIDER_TITLE = 'Provider Configuration'
+export const PROVIDER_STATUS_AVAILABLE = 'Available'
+export const PROVIDER_STATUS_UNAVAILABLE = 'Unavailable'
+export const PROVIDER_MODELS_HEADING = 'Models'
+export const PROVIDER_FALLBACK_HEADING = 'Fallback Order'
+export const PROVIDER_FALLBACK_DESCRIPTION = 'When a provider fails, requests cascade in this order.'
+export const PROVIDER_SOURCE_CONFIG = 'built-in'
+export const PROVIDER_SOURCE_DISCOVERED = 'auto-discovered'
+export const PROVIDER_SOURCE_USER = 'user-added'
+export const PROVIDER_NO_MODELS = 'No models available'
+export const PROVIDER_COL_MODEL = 'Model'
+export const PROVIDER_COL_VISION = 'Vision'
+export const PROVIDER_COL_SOURCE = 'Source'
+export const PROVIDER_SELECT_LABEL = 'Provider'
+export const PROVIDER_MODEL_SELECT_LABEL = 'Model'
+export const PROVIDER_AUTO_DEFAULT = 'Auto (default)'
+export const PROVIDER_MODEL_AUTO_FIRST = 'Auto (first available)'
+
+// Generic Buttons
+export const BTN_DISMISS = 'Dismiss'
+export const BTN_RETRY = 'Retry'
+
+// Provider Inline Labels
+export const PROVIDER_STATUS_SUFFIX_UNAVAILABLE = '(unavailable)'
+
+// Description Generation Errors
+export const DESC_ERROR_RATE_LIMIT = 'Rate limited — try a different provider or wait.'
+export const DESC_ERROR_AUTH = 'Authentication failed — check your API key.'
+export const DESC_ERROR_UNAVAILABLE = 'Provider unavailable — try a different provider.'
+export const DESC_ERROR_GENERIC = 'Description generation failed.'

--- a/apps/visualizer/frontend/src/hooks/useProviders.ts
+++ b/apps/visualizer/frontend/src/hooks/useProviders.ts
@@ -1,0 +1,49 @@
+import { useState, useEffect, useCallback } from 'react'
+import { ProvidersAPI, type Provider, type ProviderModel } from '../services/api'
+
+export function useProviders() {
+  const [providers, setProviders] = useState<Provider[]>([])
+  const [fallbackOrder, setFallbackOrder] = useState<string[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const [providerList, fallback] = await Promise.all([
+        ProvidersAPI.list(),
+        ProvidersAPI.getFallbackOrder(),
+      ])
+      setProviders(providerList)
+      setFallbackOrder(fallback.order)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load providers')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { refresh() }, [refresh])
+
+  return { providers, fallbackOrder, loading, error, refresh }
+}
+
+export function useProviderModels(providerId: string | null) {
+  const [models, setModels] = useState<ProviderModel[]>([])
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (!providerId) {
+      setModels([])
+      return
+    }
+    setLoading(true)
+    ProvidersAPI.listModels(providerId)
+      .then(setModels)
+      .catch(() => setModels([]))
+      .finally(() => setLoading(false))
+  }, [providerId])
+
+  return { models, loading }
+}

--- a/apps/visualizer/frontend/src/pages/DescriptionsPage.tsx
+++ b/apps/visualizer/frontend/src/pages/DescriptionsPage.tsx
@@ -1,11 +1,13 @@
 import { Suspense, useEffect, useMemo, useState } from 'react';
 import type { DescriptionItem, ImageDescription, Job } from '../services/api';
 import { DescriptionsAPI, JobsAPI } from '../services/api';
+import { Alert } from '../components/ui/Alert';
 import { BatchActionPanel } from '../components/descriptions/BatchActionPanel';
 import { DescriptionDetailModal } from '../components/descriptions/DescriptionDetailModal';
 import { DescriptionGrid } from '../components/descriptions/DescriptionGrid';
 import { TotalCount } from '../components/descriptions/TotalCount';
 import { useMatchOptions } from '../stores/matchOptionsContext';
+import { classifyApiError } from '../utils/classifyApiError';
 import { createResource, type Resource } from '../utils/createResource';
 import { thumbnailUrl as buildThumbUrl, fullImageUrl as buildFullUrl } from '../utils/imageUrl';
 import {
@@ -47,6 +49,7 @@ export function DescriptionsPage() {
   const [batchJob, setBatchJob] = useState<Job | null>(null);
   const [batchError, setBatchError] = useState<string | null>(null);
   const [generatingKeys, setGeneratingKeys] = useState<Set<string>>(new Set());
+  const [generateError, setGenerateError] = useState<string | null>(null);
   const [modalItem, setModalItem] = useState<DescriptionItem | null>(null);
   const [modalDescResource, setModalDescResource] = useState<Resource<{ description: ImageDescription | null }> | null>(null);
   const [refreshKey, setRefreshKey] = useState(0);
@@ -95,6 +98,7 @@ export function DescriptionsPage() {
   async function handleGenerate(item: DescriptionItem, e?: React.MouseEvent) {
     e?.stopPropagation();
     setGeneratingKeys(prev => new Set(prev).add(item.image_key));
+    setGenerateError(null);
     try {
       const res = await DescriptionsAPI.generate(
         item.image_key,
@@ -108,6 +112,8 @@ export function DescriptionsPage() {
           setModalDescResource(createResource(Promise.resolve({ description: res.description as ImageDescription })));
         }
       }
+    } catch (err) {
+      setGenerateError(classifyApiError(err));
     } finally {
       setGeneratingKeys(prev => { const next = new Set(prev); next.delete(item.image_key); return next; });
     }
@@ -174,6 +180,10 @@ export function DescriptionsPage() {
         batchError={batchError}
         onDismissError={() => setBatchError(null)}
       />
+
+      {generateError && (
+        <Alert tone="danger" message={generateError} onDismiss={() => setGenerateError(null)} />
+      )}
 
       <Suspense fallback={<p className="text-gray-500 text-center py-12">{MSG_LOADING}</p>}>
         <DescriptionGrid

--- a/apps/visualizer/frontend/src/pages/ProvidersPage.tsx
+++ b/apps/visualizer/frontend/src/pages/ProvidersPage.tsx
@@ -1,0 +1,42 @@
+import { useState, useEffect } from 'react'
+import { ProvidersAPI, type ProviderModel } from '../services/api'
+import { useProviders } from '../hooks/useProviders'
+import { ProviderCard, FallbackOrderPanel } from '../components/providers'
+import { PageLoading, PageError } from '../components/ui/page-states'
+import { PROVIDER_TITLE } from '../constants/strings'
+
+export function ProvidersPage() {
+  const { providers, fallbackOrder, loading, error } = useProviders()
+  const [expandedId, setExpandedId] = useState<string | null>(null)
+  const [modelCache, setModelCache] = useState<Record<string, ProviderModel[]>>({})
+
+  useEffect(() => {
+    if (!expandedId || modelCache[expandedId]) return
+    ProvidersAPI.listModels(expandedId).then(models => {
+      setModelCache(prev => ({ ...prev, [expandedId]: models }))
+    })
+  }, [expandedId, modelCache])
+
+  if (loading) return <PageLoading />
+  if (error) return <PageError message={error} />
+
+  return (
+    <div className="space-y-6">
+      <h2 className="text-2xl font-bold text-gray-900">{PROVIDER_TITLE}</h2>
+
+      <div className="space-y-3">
+        {providers.map(provider => (
+          <ProviderCard
+            key={provider.id}
+            provider={provider}
+            models={modelCache[provider.id] ?? []}
+            expanded={expandedId === provider.id}
+            onToggle={() => setExpandedId(prev => (prev === provider.id ? null : provider.id))}
+          />
+        ))}
+      </div>
+
+      <FallbackOrderPanel providers={providers} order={fallbackOrder} />
+    </div>
+  )
+}

--- a/apps/visualizer/frontend/src/services/api.ts
+++ b/apps/visualizer/frontend/src/services/api.ts
@@ -139,10 +139,26 @@ export const DescriptionsAPI = {
       `/descriptions/?${sp.toString()}`
     )
   },
-  generate: (imageKey: string, imageType: string, force = false, model?: string) =>
+  generate: (
+    imageKey: string,
+    imageType: string,
+    force = false,
+    model?: string,
+    providerId?: string,
+    providerModel?: string,
+  ) =>
     request<{ generated: boolean; description: ImageDescription | null }>(
       `/descriptions/${encodeURIComponent(imageKey)}/generate`,
-      { method: 'POST', body: JSON.stringify({ image_type: imageType, force, ...(model && { model }) }) },
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          image_type: imageType,
+          force,
+          ...(model && { model }),
+          ...(providerId && { provider_id: providerId }),
+          ...(providerModel && { provider_model: providerModel }),
+        }),
+      },
     ),
 }
 
@@ -294,4 +310,32 @@ export interface DumpMedia {
   matched_catalog_key?: string
   vision_result?: 'SAME' | 'DIFFERENT' | 'UNCERTAIN' | 'NO_MATCH' | 'ERROR'
   vision_score?: number
+}
+
+export interface Provider {
+  id: string
+  name: string
+  available: boolean
+}
+
+export interface ProviderModel {
+  id: string
+  name: string
+  vision: boolean
+  source: 'config' | 'discovered' | 'user'
+}
+
+export interface ProviderDefaults {
+  vision_comparison: { provider: string; model: string | null }
+  description: { provider: string; model: string | null }
+}
+
+export const ProvidersAPI = {
+  list: () => request<Provider[]>('/providers/'),
+  listModels: (providerId: string) =>
+    request<ProviderModel[]>(`/providers/${providerId}/models`),
+  getFallbackOrder: () =>
+    request<{ order: string[] }>('/providers/fallback-order'),
+  getDefaults: () =>
+    request<ProviderDefaults>('/providers/defaults'),
 }

--- a/apps/visualizer/frontend/src/utils/classifyApiError.ts
+++ b/apps/visualizer/frontend/src/utils/classifyApiError.ts
@@ -1,0 +1,14 @@
+import {
+  DESC_ERROR_RATE_LIMIT,
+  DESC_ERROR_AUTH,
+  DESC_ERROR_UNAVAILABLE,
+  DESC_ERROR_GENERIC,
+} from '../constants/strings'
+
+export function classifyApiError(err: unknown): string {
+  const message = err instanceof Error ? err.message : ''
+  if (message.includes('429')) return DESC_ERROR_RATE_LIMIT
+  if (message.includes('401')) return DESC_ERROR_AUTH
+  if (message.includes('503')) return DESC_ERROR_UNAVAILABLE
+  return DESC_ERROR_GENERIC
+}

--- a/lightroom_tagger/core/analyzer.py
+++ b/lightroom_tagger/core/analyzer.py
@@ -311,8 +311,18 @@ def extract_exif(path: str) -> dict[str, Any]:
         pass
     return result
 
-def describe_image(path: str, agent_type: str | None = None) -> dict:
-    """Generate structured description using configured agent."""
+def describe_image(path: str, agent_type: str | None = None,
+                    provider_id: str | None = None, model: str | None = None,
+                    log_callback=None) -> dict:
+    """Generate structured description using configured agent.
+
+    When *provider_id* is given the new multi-provider pipeline is used
+    (FallbackDispatcher + retry).  Otherwise falls back to the legacy
+    Ollama path for backward compatibility.
+    """
+    if provider_id is not None:
+        return _describe_image_via_provider(path, provider_id, model, log_callback)
+
     if agent_type is None:
         try:
             config = load_config()
@@ -328,6 +338,51 @@ def describe_image(path: str, agent_type: str | None = None) -> dict:
         raw = ''
 
     return parse_description_response(raw)
+
+
+def _describe_image_via_provider(path: str, provider_id: str,
+                                  model: str | None, log_callback=None) -> dict:
+    """Generate description via the unified provider pipeline."""
+    from lightroom_tagger.core.fallback import FallbackDispatcher
+    from lightroom_tagger.core.provider_registry import ProviderRegistry
+    from lightroom_tagger.core.vision_client import generate_description as _gen
+
+    registry = ProviderRegistry()
+    dispatcher = FallbackDispatcher(registry)
+
+    if model is None:
+        models = registry.list_models(provider_id)
+        model = models[0]["id"] if models else "gemma3:27b"
+
+    temp_files: list[str] = []
+    viewable = get_viewable_path(path)
+    if viewable != path:
+        temp_files.append(viewable)
+
+    compressed = compress_image(viewable)
+    if compressed != viewable:
+        temp_files.append(compressed)
+
+    try:
+        def fn_factory(client, mdl):
+            return lambda: _gen(client, mdl, compressed, log_callback=log_callback)
+
+        raw, actual_provider, actual_model = dispatcher.call_with_fallback(
+            operation="describe",
+            fn_factory=fn_factory,
+            provider_id=provider_id,
+            model=model,
+            log_callback=log_callback,
+        )
+        result = parse_description_response(raw)
+        result["_provider"] = actual_provider
+        result["_model"] = actual_model
+        return result
+    finally:
+        for f in temp_files:
+            if os.path.exists(f):
+                with contextlib.suppress(Exception):
+                    os.unlink(f)
 
 
 def run_local_agent(path: str) -> str:
@@ -369,7 +424,8 @@ def run_external_agent(path: str) -> str:
 
 
 def compare_with_vision(local_path: str, insta_path: str, log_callback=None,
-                        cached_local_path: str | None = None, compressed_insta_path: str | None = None) -> dict:
+                        cached_local_path: str | None = None, compressed_insta_path: str | None = None,
+                        provider_id: str | None = None, model: str | None = None) -> dict:
     """Compare two images using vision model via Ollama with compression.
 
     Compresses images to max VISION_MAX_DIMENSION pixels before comparison
@@ -437,7 +493,13 @@ def compare_with_vision(local_path: str, insta_path: str, log_callback=None,
                 temp_files.append(compressed_insta)
 
         # Step 3: Run vision comparison
-        result = run_vision_ollama(compressed_local, compressed_insta, log_callback=log_callback)
+        if provider_id is not None:
+            result = _compare_via_provider(
+                compressed_local, compressed_insta,
+                provider_id, model, log_callback,
+            )
+        else:
+            result = run_vision_ollama(compressed_local, compressed_insta, log_callback=log_callback)
 
         return result
 
@@ -447,6 +509,36 @@ def compare_with_vision(local_path: str, insta_path: str, log_callback=None,
             if temp_file and os.path.exists(temp_file):
                 with contextlib.suppress(Exception):
                     os.unlink(temp_file)
+
+
+def _compare_via_provider(local_path: str, insta_path: str,
+                          provider_id: str, model: str | None,
+                          log_callback=None) -> dict:
+    """Run vision comparison via the unified provider pipeline."""
+    from lightroom_tagger.core.fallback import FallbackDispatcher
+    from lightroom_tagger.core.provider_registry import ProviderRegistry
+    from lightroom_tagger.core.vision_client import compare_images as _cmp
+
+    registry = ProviderRegistry()
+    dispatcher = FallbackDispatcher(registry)
+
+    if model is None:
+        models = registry.list_models(provider_id)
+        model = models[0]["id"] if models else "gemma3:27b"
+
+    def fn_factory(client, mdl):
+        return lambda: _cmp(client, mdl, local_path, insta_path, log_callback=log_callback)
+
+    result, actual_provider, actual_model = dispatcher.call_with_fallback(
+        operation="compare",
+        fn_factory=fn_factory,
+        provider_id=provider_id,
+        model=model,
+        log_callback=log_callback,
+    )
+    result["_provider"] = actual_provider
+    result["_model"] = actual_model
+    return result
 
 
 def parse_vision_response(raw: str) -> dict:

--- a/lightroom_tagger/core/analyzer.py
+++ b/lightroom_tagger/core/analyzer.py
@@ -426,7 +426,11 @@ def run_external_agent(path: str) -> str:
 def compare_with_vision(local_path: str, insta_path: str, log_callback=None,
                         cached_local_path: str | None = None, compressed_insta_path: str | None = None,
                         provider_id: str | None = None, model: str | None = None) -> dict:
-    """Compare two images using vision model via Ollama with compression.
+    """Compare two images using a vision model with compression.
+
+    When *provider_id* is supplied, routes through the multi-provider pipeline
+    (retry + fallback via ``FallbackDispatcher``).  Otherwise falls back to the
+    legacy Ollama-only path.
 
     Compresses images to max VISION_MAX_DIMENSION pixels before comparison
     to reduce bandwidth and processing time. Supports pre-compressed paths
@@ -438,10 +442,12 @@ def compare_with_vision(local_path: str, insta_path: str, log_callback=None,
         log_callback: Optional callback for logging
         cached_local_path: Pre-compressed catalog image path (optional, uses cache if available)
         compressed_insta_path: Pre-compressed Instagram image path (optional)
+        provider_id: Provider to use (``None`` → legacy Ollama path)
+        model: Model to use with the selected provider (``None`` → provider default)
 
     Returns:
         dict with keys ``confidence`` (0-100), ``verdict`` (``SAME`` | ``DIFFERENT`` | ``UNCERTAIN``),
-        and ``reasoning`` (str).
+        ``reasoning`` (str), and when using the multi-provider path, ``_provider`` and ``_model``.
     """
     # Track all temp files for cleanup
     temp_files = []

--- a/lightroom_tagger/core/description_service.py
+++ b/lightroom_tagger/core/description_service.py
@@ -17,7 +17,10 @@ def _description_structured_is_valid(structured: dict) -> bool:
     return isinstance(summary, str) and bool(summary.strip())
 
 
-def describe_matched_image(db, catalog_key: str, force: bool = False) -> bool:
+def describe_matched_image(db, catalog_key: str, force: bool = False,
+                           provider_id: str | None = None,
+                           model: str | None = None,
+                           log_callback=None) -> bool:
     """Generate and store a description for a catalog image if needed.
 
     Returns True if a non-empty description was stored. Returns False if
@@ -35,15 +38,25 @@ def describe_matched_image(db, catalog_key: str, force: bool = False) -> bool:
     if not os.path.exists(filepath):
         return False
 
-    structured = describe_image(filepath)
+    structured = describe_image(
+        filepath, provider_id=provider_id, model=model,
+        log_callback=log_callback,
+    )
     if not _description_structured_is_valid(structured):
         return False
 
-    _store_structured(db, catalog_key, 'catalog', structured)
+    model_used = structured.pop("_model", None) or get_description_model()
+    provider_used = structured.pop("_provider", None)
+    model_label = f"{provider_used}:{model_used}" if provider_used else model_used
+
+    _store_structured(db, catalog_key, 'catalog', structured, model_label)
     return True
 
 
-def describe_instagram_image(db, media_key: str, force: bool = False) -> bool:
+def describe_instagram_image(db, media_key: str, force: bool = False,
+                             provider_id: str | None = None,
+                             model: str | None = None,
+                             log_callback=None) -> bool:
     """Generate and store a description for an Instagram image if needed.
 
     Uses the local file from instagram_dump_media. Returns True if a
@@ -60,15 +73,23 @@ def describe_instagram_image(db, media_key: str, force: bool = False) -> bool:
     if not os.path.exists(filepath):
         return False
 
-    structured = describe_image(filepath)
+    structured = describe_image(
+        filepath, provider_id=provider_id, model=model,
+        log_callback=log_callback,
+    )
     if not _description_structured_is_valid(structured):
         return False
 
-    _store_structured(db, media_key, 'instagram', structured)
+    model_used = structured.pop("_model", None) or get_description_model()
+    provider_used = structured.pop("_provider", None)
+    model_label = f"{provider_used}:{model_used}" if provider_used else model_used
+
+    _store_structured(db, media_key, 'instagram', structured, model_label)
     return True
 
 
-def _store_structured(db, image_key: str, image_type: str, structured: dict):
+def _store_structured(db, image_key: str, image_type: str, structured: dict,
+                      model_used: str | None = None):
     store_image_description(db, {
         'image_key': image_key,
         'image_type': image_type,
@@ -78,5 +99,5 @@ def _store_structured(db, image_key: str, image_type: str, structured: dict):
         'technical': structured.get('technical', {}),
         'subjects': structured.get('subjects', []),
         'best_perspective': structured.get('best_perspective', ''),
-        'model_used': get_description_model(),
+        'model_used': model_used or get_description_model(),
     })

--- a/lightroom_tagger/core/fallback.py
+++ b/lightroom_tagger/core/fallback.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
-from lightroom_tagger.core.provider_errors import NOT_RETRYABLE_ERRORS, RETRYABLE_ERRORS, ProviderError
+from lightroom_tagger.core.provider_errors import (
+    NOT_RETRYABLE_ERRORS,
+    RETRYABLE_ERRORS,
+    ModelUnavailableError,
+    ProviderError,
+)
 from lightroom_tagger.core.provider_registry import ProviderRegistry
 from lightroom_tagger.core.retry import retry_with_backoff
 
@@ -48,6 +53,8 @@ class FallbackDispatcher:
         """
         primary_id = provider_id
         order = self._build_order(primary_id)
+        if not order:
+            raise ProviderError("No available providers for operation")
         last_error: ProviderError | None = None
 
         for index, provider_id in enumerate(order):
@@ -96,5 +103,10 @@ class FallbackDispatcher:
     def _pick_fallback_model(self, provider_id: str) -> str:
         """Pick the first vision model for a fallback provider."""
         models = self._registry.list_models(provider_id)
+        if not models:
+            raise ModelUnavailableError(
+                f"No models available for fallback provider '{provider_id}'.",
+                provider=provider_id,
+            )
         vision_models = [m for m in models if m.get("vision")]
         return vision_models[0]["id"] if vision_models else models[0]["id"]

--- a/lightroom_tagger/core/fallback.py
+++ b/lightroom_tagger/core/fallback.py
@@ -46,39 +46,52 @@ class FallbackDispatcher:
         -------
         ``(result, actual_provider_id, actual_model)``
         """
-        order = self._build_order(provider_id)
+        primary_id = provider_id
+        order = self._build_order(primary_id)
         last_error: ProviderError | None = None
 
-        for idx, pid in enumerate(order):
-            client = self._registry.get_client(pid)
-            retry_config = self._registry.get_retry_config(pid)
+        for index, provider_id in enumerate(order):
+            client = self._registry.get_client(provider_id)
+            retry_config = self._registry.get_retry_config(provider_id)
 
-            current_model = model if pid == provider_id else self._pick_fallback_model(pid)
+            current_model = model if provider_id == primary_id else self._pick_fallback_model(provider_id)
 
             fn = fn_factory(client, current_model)
 
             try:
                 result = retry_with_backoff(fn, retry_config, log_callback=log_callback)
-                return result, pid, current_model
+                return result, provider_id, current_model
             except tuple(NOT_RETRYABLE_ERRORS):
                 raise
             except tuple(RETRYABLE_ERRORS) as exc:
                 last_error = exc  # type: ignore[assignment]
                 if log_callback:
-                    remaining = order[idx + 1:]
+                    remaining = order[index + 1:]
                     next_label = remaining[0] if remaining else "none"
                     log_callback(
                         "warning",
-                        f"[{operation}] {pid} failed ({type(exc).__name__}), "
+                        f"[{operation}] {provider_id} failed ({type(exc).__name__}), "
                         f"fallback -> {next_label}",
                     )
 
         raise last_error  # type: ignore[misc]
 
     def _build_order(self, primary: str) -> list[str]:
-        """Return [primary] + remaining fallback order (excluding primary)."""
-        remaining = [p for p in self._registry.fallback_order if p != primary]
-        return [primary] + remaining
+        """Return [primary] + remaining fallback order (excluding primary).
+
+        Only includes providers that are available (e.g. API key present).
+        """
+        available_ids = {
+            entry["id"]
+            for entry in self._registry.list_providers()
+            if entry.get("available")
+        }
+        full_order = [primary] + [
+            provider_id
+            for provider_id in self._registry.fallback_order
+            if provider_id != primary
+        ]
+        return [provider_id for provider_id in full_order if provider_id in available_ids]
 
     def _pick_fallback_model(self, provider_id: str) -> str:
         """Pick the first vision model for a fallback provider."""

--- a/lightroom_tagger/core/fallback.py
+++ b/lightroom_tagger/core/fallback.py
@@ -1,0 +1,87 @@
+"""FallbackDispatcher — tries selected provider, cascades through fallback
+order on retryable failures."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from lightroom_tagger.core.provider_errors import NOT_RETRYABLE_ERRORS, RETRYABLE_ERRORS, ProviderError
+from lightroom_tagger.core.provider_registry import ProviderRegistry
+from lightroom_tagger.core.retry import retry_with_backoff
+
+LogCallback = Callable[[str, str], None] | None
+
+
+class FallbackDispatcher:
+    """Wraps provider calls with retry + automatic cascade."""
+
+    def __init__(self, registry: ProviderRegistry):
+        self._registry = registry
+
+    def call_with_fallback(
+        self,
+        operation: str,
+        fn_factory: Callable,
+        provider_id: str,
+        model: str,
+        log_callback: LogCallback = None,
+    ) -> tuple[Any, str, str]:
+        """Execute *fn_factory(client, model)* with retry and fallback.
+
+        Parameters
+        ----------
+        operation:
+            Label for logging (``"compare"`` or ``"describe"``).
+        fn_factory:
+            ``(client, model) -> callable`` — returns a zero-arg callable that
+            performs the actual API call.
+        provider_id:
+            Primary provider to try first.
+        model:
+            Model to use with the primary provider.
+        log_callback:
+            Optional ``(level, message)`` logger.
+
+        Returns
+        -------
+        ``(result, actual_provider_id, actual_model)``
+        """
+        order = self._build_order(provider_id)
+        last_error: ProviderError | None = None
+
+        for idx, pid in enumerate(order):
+            client = self._registry.get_client(pid)
+            retry_config = self._registry.get_retry_config(pid)
+
+            current_model = model if pid == provider_id else self._pick_fallback_model(pid)
+
+            fn = fn_factory(client, current_model)
+
+            try:
+                result = retry_with_backoff(fn, retry_config, log_callback=log_callback)
+                return result, pid, current_model
+            except tuple(NOT_RETRYABLE_ERRORS):
+                raise
+            except tuple(RETRYABLE_ERRORS) as exc:
+                last_error = exc  # type: ignore[assignment]
+                if log_callback:
+                    remaining = order[idx + 1:]
+                    next_label = remaining[0] if remaining else "none"
+                    log_callback(
+                        "warning",
+                        f"[{operation}] {pid} failed ({type(exc).__name__}), "
+                        f"fallback -> {next_label}",
+                    )
+
+        raise last_error  # type: ignore[misc]
+
+    def _build_order(self, primary: str) -> list[str]:
+        """Return [primary] + remaining fallback order (excluding primary)."""
+        remaining = [p for p in self._registry.fallback_order if p != primary]
+        return [primary] + remaining
+
+    def _pick_fallback_model(self, provider_id: str) -> str:
+        """Pick the first vision model for a fallback provider."""
+        models = self._registry.list_models(provider_id)
+        vision_models = [m for m in models if m.get("vision")]
+        return vision_models[0]["id"] if vision_models else models[0]["id"]

--- a/lightroom_tagger/core/matcher.py
+++ b/lightroom_tagger/core/matcher.py
@@ -153,16 +153,23 @@ def score_candidates_with_vision(db, insta_image: dict, candidates: list,
 
         # Check vision comparison cache (invalidate if model changed)
         vision_cached = get_vision_comparison(db, catalog_key, insta_key)
-        current_model = get_vision_model()
+        base_vision_model = get_vision_model()
+        current_model_label = (
+            f"{provider_id}:{model or base_vision_model}"
+            if provider_id
+            else base_vision_model
+        )
         cache_valid = (
             vision_cached
-            and vision_cached.get('model_used') == current_model
+            and vision_cached.get('model_used') == current_model_label
         )
 
+        model_label = base_vision_model
         vision_reasoning = ''
         if cache_valid:
             vision_result = vision_cached['result']
             vision_score_val = vision_cached['vision_score']
+            model_label = vision_cached.get('model_used', model_label)
             consecutive_rate_limits = 0
         elif consecutive_rate_limits >= RATE_LIMIT_ABORT_THRESHOLD:
             vision_result = 'RATE_LIMITED'
@@ -183,14 +190,13 @@ def score_candidates_with_vision(db, insta_image: dict, candidates: list,
                 vision_reasoning = (vision_data.get('reasoning') or '').strip()
                 consecutive_rate_limits = 0
 
-                model_label = get_vision_model()
                 if vision_data.get('_provider'):
                     model_label = f"{vision_data['_provider']}:{vision_data.get('_model', model_label)}"
 
                 store_vision_comparison(
                     db, catalog_key, insta_key,
                     vision_result, vision_score_val,
-                    model_label,
+                    current_model_label,
                 )
             except RateLimitError as e:
                 consecutive_rate_limits += 1
@@ -246,7 +252,7 @@ def score_candidates_with_vision(db, insta_image: dict, candidates: list,
             'vision_score': vision_score_val,
             'vision_reasoning': vision_reasoning,
             'total_score': total_score_val,
-            'model_used': get_vision_model(),
+            'model_used': model_label,
             'rate_limited': vision_result == 'RATE_LIMITED',
         })
 

--- a/lightroom_tagger/core/matcher.py
+++ b/lightroom_tagger/core/matcher.py
@@ -81,7 +81,9 @@ def score_candidates_with_vision(db, insta_image: dict, candidates: list,
                                  phash_weight: float = 0.4, desc_weight: float = 0.3,
                                  vision_weight: float = 0.3,
                                  threshold: float = 0.7,
-                                 log_callback=None) -> list[dict]:
+                                 log_callback=None,
+                                 provider_id: str | None = None,
+                                 model: str | None = None) -> list[dict]:
     """Score candidates including vision comparison (one-by-one).
 
     Uses vision comparison cache to avoid re-comparing already processed pairs.
@@ -91,9 +93,14 @@ def score_candidates_with_vision(db, insta_image: dict, candidates: list,
 
     from lightroom_tagger.core.analyzer import compare_with_vision, get_vision_model, vision_score
     from lightroom_tagger.core.phash import hamming_distance
+    from lightroom_tagger.core.provider_errors import RateLimitError
+
+    RATE_LIMIT_ABORT_THRESHOLD = 3
 
     results = []
     total_candidates = len(candidates)
+    consecutive_rate_limits = 0
+    rate_limited_count = 0
     insta_filename = _os.path.basename(insta_image.get('local_path', 'unknown'))
 
     # Compress Instagram image ONCE before candidate loop
@@ -156,26 +163,44 @@ def score_candidates_with_vision(db, insta_image: dict, candidates: list,
         if cache_valid:
             vision_result = vision_cached['result']
             vision_score_val = vision_cached['vision_score']
+            consecutive_rate_limits = 0
+        elif consecutive_rate_limits >= RATE_LIMIT_ABORT_THRESHOLD:
+            vision_result = 'RATE_LIMITED'
+            vision_score_val = 0.0
+            rate_limited_count += 1
         elif insta_path and local_path:
-            # Run vision comparison with cached/prepared paths
             try:
                 vision_data = compare_with_vision(
                     local_path, insta_path,
                     log_callback=log_callback,
                     cached_local_path=cached_local_path,
-                    compressed_insta_path=compressed_insta
+                    compressed_insta_path=compressed_insta,
+                    provider_id=provider_id,
+                    model=model,
                 )
                 vision_result = vision_data['verdict']
                 vision_score_val = vision_score(vision_data['confidence'])
                 vision_reasoning = (vision_data.get('reasoning') or '').strip()
+                consecutive_rate_limits = 0
 
-                # Cache the result
+                model_label = get_vision_model()
+                if vision_data.get('_provider'):
+                    model_label = f"{vision_data['_provider']}:{vision_data.get('_model', model_label)}"
+
                 store_vision_comparison(
                     db, catalog_key, insta_key,
                     vision_result, vision_score_val,
-                    get_vision_model()
+                    model_label,
                 )
+            except RateLimitError as e:
+                consecutive_rate_limits += 1
+                rate_limited_count += 1
+                if log_callback:
+                    log_callback('warning', f'[{insta_filename}] Rate limited for {catalog_key} ({consecutive_rate_limits} consecutive)')
+                vision_result = 'RATE_LIMITED'
+                vision_score_val = 0.0
             except Exception as e:
+                consecutive_rate_limits = 0
                 if log_callback:
                     log_callback('error', f'[{insta_filename}] Vision error for {catalog_key}: {e}')
                 vision_result = 'ERROR'
@@ -222,6 +247,7 @@ def score_candidates_with_vision(db, insta_image: dict, candidates: list,
             'vision_reasoning': vision_reasoning,
             'total_score': total_score_val,
             'model_used': get_vision_model(),
+            'rate_limited': vision_result == 'RATE_LIMITED',
         })
 
     # Cleanup Instagram temp file
@@ -243,7 +269,9 @@ def score_candidates_with_vision(db, insta_image: dict, candidates: list,
 
 def match_image(db, insta_image: dict, threshold: float = 0.7,
                 phash_weight: float = 0.4, desc_weight: float = 0.3,
-                vision_weight: float = 0.3) -> list[dict]:
+                vision_weight: float = 0.3,
+                provider_id: str | None = None,
+                model: str | None = None) -> list[dict]:
     """Match single Instagram image against catalog with vision comparison."""
     insta_exif = insta_image.get('exif', {})
 
@@ -256,6 +284,8 @@ def match_image(db, insta_image: dict, threshold: float = 0.7,
         db, insta_image, candidates,
         phash_weight, desc_weight, vision_weight,
         threshold=threshold,
+        provider_id=provider_id,
+        model=model,
     )
 
     # Get best match (highest score) if above threshold

--- a/lightroom_tagger/core/matcher.py
+++ b/lightroom_tagger/core/matcher.py
@@ -154,14 +154,15 @@ def score_candidates_with_vision(db, insta_image: dict, candidates: list,
         # Check vision comparison cache (invalidate if model changed)
         vision_cached = get_vision_comparison(db, catalog_key, insta_key)
         base_vision_model = get_vision_model()
-        current_model_label = (
+        # Requested label for cache lookup only; pipeline may pick a different default model.
+        requested_model_label = (
             f"{provider_id}:{model or base_vision_model}"
             if provider_id
             else base_vision_model
         )
         cache_valid = (
             vision_cached
-            and vision_cached.get('model_used') == current_model_label
+            and vision_cached.get('model_used') == requested_model_label
         )
 
         model_label = base_vision_model
@@ -191,12 +192,14 @@ def score_candidates_with_vision(db, insta_image: dict, candidates: list,
                 consecutive_rate_limits = 0
 
                 if vision_data.get('_provider'):
-                    model_label = f"{vision_data['_provider']}:{vision_data.get('_model', model_label)}"
+                    ap = vision_data['_provider']
+                    am = vision_data.get('_model')
+                    model_label = f"{ap}:{am}" if am is not None else f"{ap}:"
 
                 store_vision_comparison(
                     db, catalog_key, insta_key,
                     vision_result, vision_score_val,
-                    current_model_label,
+                    model_label,
                 )
             except RateLimitError as e:
                 consecutive_rate_limits += 1

--- a/lightroom_tagger/core/provider_errors.py
+++ b/lightroom_tagger/core/provider_errors.py
@@ -1,0 +1,64 @@
+"""Exception hierarchy for vision provider errors.
+
+All errors inherit from ProviderError. RETRYABLE_ERRORS are retried with
+backoff then cascaded to fallback providers. NOT_RETRYABLE_ERRORS are surfaced
+immediately — no retry, no fallback.
+"""
+
+
+class ProviderError(Exception):
+    """Base for all provider errors."""
+
+    def __init__(
+        self,
+        message: str,
+        provider: str | None = None,
+        model: str | None = None,
+        retry_after: float | None = None,
+    ):
+        super().__init__(message)
+        self.provider = provider
+        self.model = model
+        self.retry_after = retry_after
+
+
+class RateLimitError(ProviderError):
+    """429 — quota exceeded."""
+
+
+class TimeoutError(ProviderError):
+    """Request timed out."""
+
+
+class ConnectionError(ProviderError):
+    """Can't reach provider (Ollama not running, DNS failure)."""
+
+
+class ModelUnavailableError(ProviderError):
+    """503 — server overloaded or model not loaded."""
+
+
+class ContextLengthError(ProviderError):
+    """Token/context limit exceeded — retry with smaller image."""
+
+
+class AuthenticationError(ProviderError):
+    """401/403 — bad or missing API key."""
+
+
+class InvalidRequestError(ProviderError):
+    """400 — bad model name, unsupported input format."""
+
+
+RETRYABLE_ERRORS: frozenset[type[ProviderError]] = frozenset({
+    RateLimitError,
+    TimeoutError,
+    ConnectionError,
+    ModelUnavailableError,
+    ContextLengthError,
+})
+
+NOT_RETRYABLE_ERRORS: frozenset[type[ProviderError]] = frozenset({
+    AuthenticationError,
+    InvalidRequestError,
+})

--- a/lightroom_tagger/core/provider_registry.py
+++ b/lightroom_tagger/core/provider_registry.py
@@ -62,11 +62,13 @@ class ProviderRegistry:
         base_url = self._resolve_base_url(pconfig)
         api_key = self._resolve_api_key(pconfig)
         extra_headers = pconfig.get("extra_headers", {})
-        return openai.OpenAI(
+        client = openai.OpenAI(
             base_url=base_url,
             api_key=api_key,
             default_headers=extra_headers or None,
         )
+        client._provider_id = provider_id  # type: ignore[attr-defined]
+        return client
 
     def get_retry_config(self, provider_id: str) -> dict:
         pconfig = self._providers[provider_id]

--- a/lightroom_tagger/core/provider_registry.py
+++ b/lightroom_tagger/core/provider_registry.py
@@ -89,7 +89,10 @@ class ProviderRegistry:
         host = os.environ.get(env_var, "") if env_var else ""
         default = pconfig.get("base_url_default", "")
         if host:
-            return host.rstrip("/") + "/v1"
+            base = host.rstrip("/")
+            if not base.endswith("/v1"):
+                base = base + "/v1"
+            return base
         return default
 
     def _resolve_api_key(self, pconfig: dict) -> str:

--- a/lightroom_tagger/core/provider_registry.py
+++ b/lightroom_tagger/core/provider_registry.py
@@ -1,0 +1,125 @@
+"""Provider registry — loads providers.json, auto-discovers Ollama models,
+returns configured openai.OpenAI clients."""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+import openai
+
+_CONFIG_PATH = Path(__file__).parent / "providers.json"
+
+
+class ProviderRegistry:
+    """Central registry of vision/LLM providers and their models."""
+
+    def __init__(self, config_path: Path = _CONFIG_PATH):
+        with open(config_path) as f:
+            self._config: dict[str, Any] = json.load(f)
+        self._providers: dict[str, dict] = self._config["providers"]
+        self._retry_defaults: dict = self._config.get("retry_defaults", {})
+        self._discovered_cache: dict[str, list[dict]] = {}
+
+    @property
+    def fallback_order(self) -> list[str]:
+        return self._config.get("fallback_order", list(self._providers.keys()))
+
+    @property
+    def defaults(self) -> dict[str, dict]:
+        return self._config.get("defaults", {})
+
+    def list_providers(self) -> list[dict]:
+        result = []
+        for pid, pconfig in self._providers.items():
+            result.append({
+                "id": pid,
+                "name": pconfig["name"],
+                "available": self._is_available(pid, pconfig),
+            })
+        return result
+
+    def list_models(self, provider_id: str) -> list[dict]:
+        if provider_id not in self._providers:
+            raise KeyError(f"Unknown provider: {provider_id}")
+
+        pconfig = self._providers[provider_id]
+        models: list[dict] = []
+
+        for m in pconfig.get("models", []):
+            models.append({**m, "source": "config"})
+
+        if pconfig.get("auto_discover"):
+            models.extend(self._discover_models(provider_id, pconfig))
+
+        return models
+
+    def get_client(self, provider_id: str) -> openai.OpenAI:
+        pconfig = self._providers[provider_id]
+        base_url = self._resolve_base_url(pconfig)
+        api_key = self._resolve_api_key(pconfig)
+        extra_headers = pconfig.get("extra_headers", {})
+        return openai.OpenAI(
+            base_url=base_url,
+            api_key=api_key,
+            default_headers=extra_headers or None,
+        )
+
+    def get_retry_config(self, provider_id: str) -> dict:
+        pconfig = self._providers[provider_id]
+        provider_retry = pconfig.get("retry", {})
+        merged = {**self._retry_defaults, **provider_retry}
+        return merged
+
+    def _is_available(self, provider_id: str, pconfig: dict) -> bool:
+        if "api_key" in pconfig:
+            return True
+        api_key_env = pconfig.get("api_key_env")
+        if api_key_env:
+            return bool(os.environ.get(api_key_env))
+        return False
+
+    def _resolve_base_url(self, pconfig: dict) -> str:
+        if "base_url" in pconfig:
+            return pconfig["base_url"]
+        env_var = pconfig.get("base_url_env")
+        host = os.environ.get(env_var, "") if env_var else ""
+        default = pconfig.get("base_url_default", "")
+        if host:
+            return host.rstrip("/") + "/v1"
+        return default
+
+    def _resolve_api_key(self, pconfig: dict) -> str:
+        if "api_key" in pconfig:
+            return pconfig["api_key"]
+        env_var = pconfig.get("api_key_env")
+        return os.environ.get(env_var, "") if env_var else ""
+
+    def _discover_models(self, provider_id: str, pconfig: dict) -> list[dict]:
+        if provider_id in self._discovered_cache:
+            return self._discovered_cache[provider_id]
+
+        base_url = self._resolve_base_url(pconfig)
+        tags_url = base_url.replace("/v1", "/api/tags")
+
+        try:
+            with urllib.request.urlopen(tags_url, timeout=5) as resp:
+                data = json.loads(resp.read())
+        except Exception:
+            self._discovered_cache[provider_id] = []
+            return []
+
+        models = []
+        for m in data.get("models", []):
+            models.append({
+                "id": m["name"],
+                "name": m["name"],
+                "vision": True,
+                "source": "discovered",
+            })
+
+        self._discovered_cache[provider_id] = models
+        return models

--- a/lightroom_tagger/core/providers.json
+++ b/lightroom_tagger/core/providers.json
@@ -1,0 +1,58 @@
+{
+  "retry_defaults": {
+    "max_retries": 3,
+    "backoff_seconds": [2, 8, 32],
+    "respect_retry_after": true
+  },
+  "providers": {
+    "ollama": {
+      "name": "Ollama (Local)",
+      "base_url_env": "OLLAMA_HOST",
+      "base_url_default": "http://localhost:11434/v1",
+      "api_key": "ollama",
+      "auto_discover": true,
+      "extra_headers": {},
+      "retry": { "max_retries": 2, "backoff_seconds": [1, 3] },
+      "models": []
+    },
+    "nvidia_nim": {
+      "name": "NVIDIA NIM",
+      "base_url": "https://integrate.api.nvidia.com/v1",
+      "api_key_env": "NVIDIA_NIM_API_KEY",
+      "auto_discover": false,
+      "extra_headers": {},
+      "retry": {},
+      "models": [
+        { "id": "meta/llama-4-maverick-17b-128e-instruct", "name": "Llama 4 Maverick 17B", "vision": true },
+        { "id": "qwen/qwen3.5-397b-a17b", "name": "Qwen 3.5 397B VLM", "vision": true },
+        { "id": "microsoft/phi-4-multimodal-instruct", "name": "Phi-4 Multimodal", "vision": true },
+        { "id": "microsoft/phi-3.5-vision-instruct", "name": "Phi-3.5 Vision 4.2B", "vision": true },
+        { "id": "nvidia/llama-3.1-nemotron-nano-vl-8b-v1", "name": "Nemotron Nano VL 8B", "vision": true },
+        { "id": "google/paligemma", "name": "PaLiGemma", "vision": true }
+      ]
+    },
+    "openrouter": {
+      "name": "OpenRouter",
+      "base_url": "https://openrouter.ai/api/v1",
+      "api_key_env": "OPENROUTER_API_KEY",
+      "auto_discover": false,
+      "extra_headers": {
+        "HTTP-Referer": "lightroom-tagger",
+        "X-Title": "Lightroom Tagger"
+      },
+      "retry": {},
+      "models": [
+        { "id": "anthropic/claude-sonnet-4", "name": "Claude Sonnet 4", "vision": true },
+        { "id": "google/gemini-2.5-flash", "name": "Gemini 2.5 Flash", "vision": true },
+        { "id": "openai/gpt-4.1", "name": "GPT-4.1", "vision": true },
+        { "id": "meta-llama/llama-4-maverick", "name": "Llama 4 Maverick", "vision": true },
+        { "id": "qwen/qwen-2.5-vl-72b-instruct", "name": "Qwen 2.5 VL 72B", "vision": true }
+      ]
+    }
+  },
+  "defaults": {
+    "vision_comparison": { "provider": "ollama", "model": null },
+    "description": { "provider": "ollama", "model": null }
+  },
+  "fallback_order": ["ollama", "nvidia_nim", "openrouter"]
+}

--- a/lightroom_tagger/core/retry.py
+++ b/lightroom_tagger/core/retry.py
@@ -1,0 +1,72 @@
+"""Configurable retry with exponential backoff for provider calls."""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Callable, TypeVar
+
+from lightroom_tagger.core.provider_errors import (
+    NOT_RETRYABLE_ERRORS,
+    RETRYABLE_ERRORS,
+    ProviderError,
+)
+
+T = TypeVar("T")
+
+
+def retry_with_backoff(
+    fn: Callable[[], T],
+    retry_config: dict[str, Any],
+    log_callback: Callable[[str, str], None] | None = None,
+) -> T:
+    """Call *fn* with retry on retryable ``ProviderError`` subclasses.
+
+    Parameters
+    ----------
+    fn:
+        Zero-arg callable (bind args with ``functools.partial`` or lambda).
+    retry_config:
+        ``{"max_retries": int, "backoff_seconds": list[float], "respect_retry_after": bool}``
+    log_callback:
+        Optional ``(level, message)`` logger.
+
+    Returns the result of *fn* on success.
+    Raises the last ``ProviderError`` if all retries are exhausted.
+    Raises immediately for non-retryable errors.
+    """
+    max_retries: int = retry_config.get("max_retries", 3)
+    backoff: list[float] = retry_config.get("backoff_seconds", [2, 8, 32])
+    respect_retry_after: bool = retry_config.get("respect_retry_after", True)
+
+    last_error: ProviderError | None = None
+
+    for attempt in range(1 + max_retries):
+        try:
+            return fn()
+        except tuple(NOT_RETRYABLE_ERRORS) as exc:
+            raise
+        except tuple(RETRYABLE_ERRORS) as exc:
+            last_error = exc  # type: ignore[assignment]
+
+            if attempt >= max_retries:
+                break
+
+            wait = backoff[attempt] if attempt < len(backoff) else backoff[-1]
+
+            if (
+                respect_retry_after
+                and isinstance(exc, ProviderError)
+                and getattr(exc, "retry_after", None) is not None
+            ):
+                wait = exc.retry_after  # type: ignore[assignment]
+
+            if log_callback:
+                log_callback(
+                    "warning",
+                    f"Retry {attempt + 1}/{max_retries} after {type(exc).__name__}: "
+                    f"{exc} — waiting {wait}s",
+                )
+
+            time.sleep(wait)
+
+    raise last_error  # type: ignore[misc]

--- a/lightroom_tagger/core/test_fallback.py
+++ b/lightroom_tagger/core/test_fallback.py
@@ -17,6 +17,9 @@ def _mock_registry(available_providers=None):
 
     registry = MagicMock()
     registry.fallback_order = available_providers
+    registry.list_providers.return_value = [
+        {"id": pid, "name": pid, "available": True} for pid in available_providers
+    ]
     registry.get_client.return_value = MagicMock()
     registry.get_retry_config.return_value = {
         "max_retries": 0,

--- a/lightroom_tagger/core/test_fallback.py
+++ b/lightroom_tagger/core/test_fallback.py
@@ -1,0 +1,167 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from lightroom_tagger.core.provider_errors import (
+    AuthenticationError,
+    ConnectionError,
+    RateLimitError,
+)
+from lightroom_tagger.core.fallback import FallbackDispatcher
+
+
+def _mock_registry(available_providers=None):
+    """Build a mock ProviderRegistry."""
+    if available_providers is None:
+        available_providers = ["ollama", "nvidia_nim", "openrouter"]
+
+    registry = MagicMock()
+    registry.fallback_order = available_providers
+    registry.get_client.return_value = MagicMock()
+    registry.get_retry_config.return_value = {
+        "max_retries": 0,
+        "backoff_seconds": [],
+        "respect_retry_after": False,
+    }
+    registry.list_models.return_value = [{"id": "test-model", "vision": True, "source": "config"}]
+    return registry
+
+
+class TestPrimarySuccess:
+    def test_should_return_result_from_primary_provider(self):
+        registry = _mock_registry()
+        dispatcher = FallbackDispatcher(registry)
+
+        result, provider, model = dispatcher.call_with_fallback(
+            operation="compare",
+            fn_factory=lambda client, model: lambda: {"verdict": "SAME"},
+            provider_id="ollama",
+            model="gemma3:27b",
+        )
+        assert result == {"verdict": "SAME"}
+        assert provider == "ollama"
+        assert model == "gemma3:27b"
+
+    def test_should_not_try_fallback_on_success(self):
+        registry = _mock_registry()
+        dispatcher = FallbackDispatcher(registry)
+
+        dispatcher.call_with_fallback(
+            operation="compare",
+            fn_factory=lambda client, model: lambda: "ok",
+            provider_id="ollama",
+            model="gemma3:27b",
+        )
+        registry.get_client.assert_called_once_with("ollama")
+
+
+class TestFallbackCascade:
+    @patch("time.sleep")
+    def test_should_cascade_to_next_provider_on_failure(self, mock_sleep):
+        registry = _mock_registry()
+        dispatcher = FallbackDispatcher(registry)
+
+        call_count = {"n": 0}
+
+        def fn_factory(client, model):
+            def fn():
+                call_count["n"] += 1
+                if call_count["n"] == 1:
+                    raise RateLimitError("429")
+                return "from_fallback"
+            return fn
+
+        result, provider, model = dispatcher.call_with_fallback(
+            operation="compare",
+            fn_factory=fn_factory,
+            provider_id="ollama",
+            model="gemma3:27b",
+        )
+        assert result == "from_fallback"
+        assert provider == "nvidia_nim"
+
+    @patch("time.sleep")
+    def test_should_try_all_providers_before_raising(self, mock_sleep):
+        registry = _mock_registry()
+        dispatcher = FallbackDispatcher(registry)
+
+        def fn_factory(client, model):
+            return lambda: (_ for _ in ()).throw(ConnectionError("down"))
+
+        with pytest.raises(ConnectionError):
+            dispatcher.call_with_fallback(
+                operation="compare",
+                fn_factory=fn_factory,
+                provider_id="ollama",
+                model="gemma3:27b",
+            )
+        assert registry.get_client.call_count == 3
+
+    @patch("time.sleep")
+    def test_should_use_default_model_for_fallback_providers(self, mock_sleep):
+        registry = _mock_registry()
+        dispatcher = FallbackDispatcher(registry)
+
+        models_used = []
+
+        def fn_factory(client, model):
+            models_used.append(model)
+            def fn():
+                if len(models_used) == 1:
+                    raise RateLimitError("429")
+                return "ok"
+            return fn
+
+        dispatcher.call_with_fallback(
+            operation="compare",
+            fn_factory=fn_factory,
+            provider_id="ollama",
+            model="gemma3:27b",
+        )
+        assert models_used[0] == "gemma3:27b"
+        assert models_used[1] == "test-model"
+
+
+class TestNonRetryableSkipsFallback:
+    def test_should_raise_immediately_on_auth_error(self):
+        registry = _mock_registry()
+        dispatcher = FallbackDispatcher(registry)
+
+        def fn_factory(client, model):
+            return lambda: (_ for _ in ()).throw(AuthenticationError("bad key"))
+
+        with pytest.raises(AuthenticationError):
+            dispatcher.call_with_fallback(
+                operation="compare",
+                fn_factory=fn_factory,
+                provider_id="ollama",
+                model="gemma3:27b",
+            )
+        registry.get_client.assert_called_once()
+
+
+class TestLogCallback:
+    @patch("time.sleep")
+    def test_should_log_fallback_transitions(self, mock_sleep):
+        registry = _mock_registry()
+        dispatcher = FallbackDispatcher(registry)
+        log = MagicMock()
+
+        call_count = {"n": 0}
+        def fn_factory(client, model):
+            def fn():
+                call_count["n"] += 1
+                if call_count["n"] == 1:
+                    raise RateLimitError("429")
+                return "ok"
+            return fn
+
+        dispatcher.call_with_fallback(
+            operation="compare",
+            fn_factory=fn_factory,
+            provider_id="ollama",
+            model="gemma3:27b",
+            log_callback=log,
+        )
+        log_messages = " ".join(str(c) for c in log.call_args_list)
+        assert "fallback" in log_messages.lower() or "nvidia_nim" in log_messages

--- a/lightroom_tagger/core/test_fallback.py
+++ b/lightroom_tagger/core/test_fallback.py
@@ -5,6 +5,8 @@ import pytest
 from lightroom_tagger.core.provider_errors import (
     AuthenticationError,
     ConnectionError,
+    ModelUnavailableError,
+    ProviderError,
     RateLimitError,
 )
 from lightroom_tagger.core.fallback import FallbackDispatcher
@@ -141,6 +143,57 @@ class TestNonRetryableSkipsFallback:
                 model="gemma3:27b",
             )
         registry.get_client.assert_called_once()
+
+
+class TestEmptyOrder:
+    def test_should_raise_provider_error_when_no_providers_available(self):
+        registry = MagicMock()
+        registry.fallback_order = ["ollama", "nvidia_nim"]
+        registry.list_providers.return_value = [
+            {"id": "ollama", "name": "Ollama", "available": False},
+            {"id": "nvidia_nim", "name": "NIM", "available": False},
+        ]
+        dispatcher = FallbackDispatcher(registry)
+
+        with pytest.raises(ProviderError, match="No available providers"):
+            dispatcher.call_with_fallback(
+                operation="compare",
+                fn_factory=lambda c, m: lambda: "never",
+                provider_id="ollama",
+                model="gemma3:27b",
+            )
+
+
+class TestEmptyFallbackModels:
+    @patch("time.sleep")
+    def test_should_raise_model_unavailable_when_fallback_has_no_models(self, mock_sleep):
+        registry = MagicMock()
+        registry.fallback_order = ["ollama", "nvidia_nim"]
+        registry.list_providers.return_value = [
+            {"id": "ollama", "name": "ollama", "available": True},
+            {"id": "nvidia_nim", "name": "nvidia_nim", "available": True},
+        ]
+        registry.get_client.return_value = MagicMock()
+        registry.get_retry_config.return_value = {
+            "max_retries": 0,
+            "backoff_seconds": [],
+            "respect_retry_after": False,
+        }
+        registry.list_models.side_effect = lambda pid: (
+            [] if pid == "nvidia_nim" else [{"id": "test-model", "vision": True, "source": "config"}]
+        )
+        dispatcher = FallbackDispatcher(registry)
+
+        def fn_factory(client, model):
+            return lambda: (_ for _ in ()).throw(RateLimitError("429"))
+
+        with pytest.raises(ModelUnavailableError, match="No models available for fallback provider"):
+            dispatcher.call_with_fallback(
+                operation="compare",
+                fn_factory=fn_factory,
+                provider_id="ollama",
+                model="gemma3:27b",
+            )
 
 
 class TestLogCallback:

--- a/lightroom_tagger/core/test_matcher.py
+++ b/lightroom_tagger/core/test_matcher.py
@@ -82,6 +82,55 @@ def test_score_candidates_includes_vision():
     store_mock.assert_called_once()
 
 
+def test_score_candidates_stores_actual_provider_model_in_cache():
+    """After vision success, cache row uses _provider/_model from response, not requested default."""
+    mock_db = Mock()
+
+    insta_image = {
+        'key': 'insta_test',
+        'image_hash': 'a1b2c3d4e5f6g7h8',
+        'description': 'sunset over bay',
+        'local_path': '/tmp/insta.jpg',
+    }
+
+    candidates = [
+        {'key': 'cat1', 'image_hash': 'a1b2c3d4e5f6g7h8', 'description': 'sunset', 'local_path': '/tmp/local1.jpg'},
+    ]
+
+    vision_payload = {
+        'confidence': 100,
+        'verdict': 'SAME',
+        'reasoning': '',
+        '_provider': 'nvidia_nim',
+        '_model': 'google/paligemma',
+    }
+
+    with patch('lightroom_tagger.core.matcher.get_vision_comparison', return_value=None), \
+         patch('lightroom_tagger.core.analyzer.compare_with_vision', return_value=vision_payload), \
+         patch('lightroom_tagger.core.analyzer.vision_score', return_value=1.0), \
+         patch('lightroom_tagger.core.matcher.store_vision_comparison') as store_mock, \
+         patch('lightroom_tagger.core.analyzer.get_vision_model', return_value='gemma3:27b'), \
+         patch('lightroom_tagger.core.matcher.get_cached_phash', return_value=None), \
+         patch('lightroom_tagger.core.matcher.get_or_create_cached_image', return_value=None), \
+         patch('lightroom_tagger.core.matcher.InstagramCache') as mock_insta_cache, \
+         patch('lightroom_tagger.core.phash.hamming_distance', return_value=0):
+        mock_insta_cache.return_value.compress_instagram_image.return_value = '/tmp/insta.jpg'
+        mock_insta_cache.return_value.cleanup.return_value = None
+
+        results = score_candidates_with_vision(
+            mock_db, insta_image, candidates,
+            phash_weight=0.4, desc_weight=0.3, vision_weight=0.3,
+            provider_id='ollama',
+            model=None,
+        )
+
+    assert len(results) == 1
+    assert results[0]['model_used'] == 'nvidia_nim:google/paligemma'
+    store_mock.assert_called_once()
+    _db, cat, insta, _result, _score, model_used = store_mock.call_args[0]
+    assert model_used == 'nvidia_nim:google/paligemma'
+
+
 def test_score_candidates_uses_cache():
     """Should use cached vision comparison when available."""
     mock_db = Mock()

--- a/lightroom_tagger/core/test_provider_errors.py
+++ b/lightroom_tagger/core/test_provider_errors.py
@@ -1,0 +1,60 @@
+from lightroom_tagger.core.provider_errors import (
+    ProviderError,
+    RateLimitError,
+    TimeoutError,
+    ConnectionError,
+    ModelUnavailableError,
+    ContextLengthError,
+    AuthenticationError,
+    InvalidRequestError,
+    RETRYABLE_ERRORS,
+    NOT_RETRYABLE_ERRORS,
+)
+
+import pytest
+
+
+class TestProviderErrorHierarchy:
+    @pytest.mark.parametrize("cls", [
+        RateLimitError, TimeoutError, ConnectionError,
+        ModelUnavailableError, ContextLengthError,
+        AuthenticationError, InvalidRequestError,
+    ])
+    def test_should_inherit_from_provider_error(self, cls):
+        assert issubclass(cls, ProviderError)
+
+    def test_should_include_retryable_errors(self):
+        for cls in (RateLimitError, TimeoutError, ConnectionError,
+                    ModelUnavailableError, ContextLengthError):
+            assert cls in RETRYABLE_ERRORS
+
+    def test_should_exclude_non_retryable_from_retryable_set(self):
+        assert AuthenticationError not in RETRYABLE_ERRORS
+        assert InvalidRequestError not in RETRYABLE_ERRORS
+
+    def test_should_include_non_retryable_errors(self):
+        assert AuthenticationError in NOT_RETRYABLE_ERRORS
+        assert InvalidRequestError in NOT_RETRYABLE_ERRORS
+
+    def test_should_exclude_retryable_from_non_retryable_set(self):
+        assert RateLimitError not in NOT_RETRYABLE_ERRORS
+        assert TimeoutError not in NOT_RETRYABLE_ERRORS
+
+    def test_should_carry_provider_and_model_context(self):
+        err = RateLimitError("too fast", provider="ollama", model="gemma3:27b")
+        assert err.provider == "ollama"
+        assert err.model == "gemma3:27b"
+        assert "too fast" in str(err)
+
+    def test_should_default_context_to_none(self):
+        err = ProviderError("generic")
+        assert err.provider is None
+        assert err.model is None
+
+    def test_should_carry_retry_after(self):
+        err = RateLimitError("too fast", provider="openrouter", retry_after=30)
+        assert err.retry_after == 30
+
+    def test_should_default_retry_after_to_none(self):
+        err = RateLimitError("too fast")
+        assert err.retry_after is None

--- a/lightroom_tagger/core/test_provider_registry.py
+++ b/lightroom_tagger/core/test_provider_registry.py
@@ -123,6 +123,22 @@ class TestGetClient:
             client = registry.get_client("ollama")
             assert "myhost" in str(client.base_url)
 
+    def test_should_not_append_v1_twice_when_ollama_host_already_has_v1(self):
+        with patch.dict(os.environ, {"OLLAMA_HOST": "http://localhost:11434/v1"}):
+            registry = ProviderRegistry()
+            client = registry.get_client("ollama")
+            url = str(client.base_url).rstrip("/")
+            assert url.endswith("/v1")
+            assert "/v1/v1" not in url
+
+    def test_should_not_append_v1_twice_when_ollama_host_has_trailing_slash_and_v1(self):
+        with patch.dict(os.environ, {"OLLAMA_HOST": "http://localhost:11434/v1/"}):
+            registry = ProviderRegistry()
+            client = registry.get_client("ollama")
+            url = str(client.base_url).rstrip("/")
+            assert url.endswith("/v1")
+            assert "/v1/v1" not in url
+
     def test_should_use_default_ollama_url_when_env_unset(self):
         with patch.dict(os.environ, {}, clear=True):
             registry = ProviderRegistry()

--- a/lightroom_tagger/core/test_provider_registry.py
+++ b/lightroom_tagger/core/test_provider_registry.py
@@ -1,0 +1,162 @@
+import json
+import os
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from lightroom_tagger.core.provider_registry import ProviderRegistry
+
+
+class TestListProviders:
+    def test_should_load_all_providers_from_config(self):
+        registry = ProviderRegistry()
+        providers = registry.list_providers()
+        ids = [p["id"] for p in providers]
+        assert "ollama" in ids
+        assert "nvidia_nim" in ids
+        assert "openrouter" in ids
+
+    def test_should_include_provider_name(self):
+        registry = ProviderRegistry()
+        providers = {p["id"]: p for p in registry.list_providers()}
+        assert providers["ollama"]["name"] == "Ollama (Local)"
+        assert providers["nvidia_nim"]["name"] == "NVIDIA NIM"
+
+    def test_should_mark_provider_unavailable_without_api_key(self):
+        with patch.dict(os.environ, {}, clear=True):
+            registry = ProviderRegistry()
+            providers = {p["id"]: p for p in registry.list_providers()}
+            assert providers["nvidia_nim"]["available"] is False
+            assert providers["openrouter"]["available"] is False
+
+    def test_should_mark_provider_available_with_api_key(self):
+        with patch.dict(os.environ, {"NVIDIA_NIM_API_KEY": "test-key"}, clear=False):
+            registry = ProviderRegistry()
+            providers = {p["id"]: p for p in registry.list_providers()}
+            assert providers["nvidia_nim"]["available"] is True
+
+    def test_should_always_mark_ollama_available(self):
+        """Ollama uses a static api_key, no env var needed for auth."""
+        with patch.dict(os.environ, {}, clear=True):
+            registry = ProviderRegistry()
+            providers = {p["id"]: p for p in registry.list_providers()}
+            assert providers["ollama"]["available"] is True
+
+
+class TestListModels:
+    def test_should_list_static_models_for_nvidia(self):
+        registry = ProviderRegistry()
+        models = registry.list_models("nvidia_nim")
+        model_ids = [m["id"] for m in models]
+        assert "meta/llama-4-maverick-17b-128e-instruct" in model_ids
+        assert "google/paligemma" in model_ids
+
+    def test_should_list_static_models_for_openrouter(self):
+        registry = ProviderRegistry()
+        models = registry.list_models("openrouter")
+        model_ids = [m["id"] for m in models]
+        assert "anthropic/claude-sonnet-4" in model_ids
+        assert "openai/gpt-4.1" in model_ids
+
+    def test_should_include_model_source(self):
+        registry = ProviderRegistry()
+        models = registry.list_models("nvidia_nim")
+        assert all(m["source"] == "config" for m in models)
+
+    def test_should_raise_for_unknown_provider(self):
+        registry = ProviderRegistry()
+        with pytest.raises(KeyError):
+            registry.list_models("nonexistent")
+
+    def test_should_auto_discover_ollama_models(self):
+        fake_tags = json.dumps({
+            "models": [
+                {"name": "gemma3:27b", "details": {"family": "gemma"}},
+                {"name": "qwen3-vl:235b", "details": {"family": "qwen"}},
+            ]
+        }).encode()
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = fake_tags
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            registry = ProviderRegistry()
+            models = registry.list_models("ollama")
+            model_ids = [m["id"] for m in models]
+            assert "gemma3:27b" in model_ids
+            assert "qwen3-vl:235b" in model_ids
+
+    def test_should_mark_discovered_models_source(self):
+        fake_tags = json.dumps({
+            "models": [{"name": "llava:13b", "details": {}}]
+        }).encode()
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = fake_tags
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            registry = ProviderRegistry()
+            models = registry.list_models("ollama")
+            discovered = [m for m in models if m["id"] == "llava:13b"]
+            assert len(discovered) == 1
+            assert discovered[0]["source"] == "discovered"
+
+    def test_should_gracefully_handle_ollama_unreachable(self):
+        with patch("urllib.request.urlopen", side_effect=OSError("connection refused")):
+            registry = ProviderRegistry()
+            models = registry.list_models("ollama")
+            assert models == []
+
+
+class TestGetClient:
+    def test_should_return_openai_client_for_provider(self):
+        with patch.dict(os.environ, {"NVIDIA_NIM_API_KEY": "test-key"}):
+            registry = ProviderRegistry()
+            client = registry.get_client("nvidia_nim")
+            assert str(client.base_url).rstrip("/").endswith("integrate.api.nvidia.com/v1")
+
+    def test_should_resolve_ollama_base_url_from_env(self):
+        with patch.dict(os.environ, {"OLLAMA_HOST": "http://myhost:5000"}):
+            registry = ProviderRegistry()
+            client = registry.get_client("ollama")
+            assert "myhost" in str(client.base_url)
+
+    def test_should_use_default_ollama_url_when_env_unset(self):
+        with patch.dict(os.environ, {}, clear=True):
+            registry = ProviderRegistry()
+            client = registry.get_client("ollama")
+            assert "localhost:11434" in str(client.base_url)
+
+    def test_should_include_extra_headers_for_openrouter(self):
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+            registry = ProviderRegistry()
+            client = registry.get_client("openrouter")
+            assert client._custom_headers.get("HTTP-Referer") == "lightroom-tagger"
+
+
+class TestRetryConfig:
+    def test_should_get_retry_config_with_provider_override(self):
+        registry = ProviderRegistry()
+        config = registry.get_retry_config("ollama")
+        assert config["max_retries"] == 2
+        assert config["backoff_seconds"] == [1, 3]
+
+    def test_should_fall_back_to_global_defaults(self):
+        registry = ProviderRegistry()
+        config = registry.get_retry_config("nvidia_nim")
+        assert config["max_retries"] == 3
+        assert config["backoff_seconds"] == [2, 8, 32]
+        assert config["respect_retry_after"] is True
+
+
+class TestFallbackOrder:
+    def test_should_return_fallback_order_from_config(self):
+        registry = ProviderRegistry()
+        assert registry.fallback_order == ["ollama", "nvidia_nim", "openrouter"]
+
+    def test_should_return_defaults_from_config(self):
+        registry = ProviderRegistry()
+        assert registry.defaults["vision_comparison"]["provider"] == "ollama"
+        assert registry.defaults["description"]["provider"] == "ollama"

--- a/lightroom_tagger/core/test_retry.py
+++ b/lightroom_tagger/core/test_retry.py
@@ -1,0 +1,102 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from lightroom_tagger.core.provider_errors import (
+    AuthenticationError,
+    ConnectionError,
+    InvalidRequestError,
+    RateLimitError,
+    TimeoutError,
+)
+from lightroom_tagger.core.retry import retry_with_backoff
+
+DEFAULT_CONFIG = {"max_retries": 3, "backoff_seconds": [1, 2, 4], "respect_retry_after": True}
+
+
+class TestRetrySuccess:
+    def test_should_return_result_on_first_success(self):
+        fn = MagicMock(return_value="ok")
+        result = retry_with_backoff(fn, DEFAULT_CONFIG)
+        assert result == "ok"
+        assert fn.call_count == 1
+
+    @patch("time.sleep")
+    def test_should_succeed_after_transient_failure(self, mock_sleep):
+        fn = MagicMock(side_effect=[RateLimitError("429"), "ok"])
+        result = retry_with_backoff(fn, DEFAULT_CONFIG)
+        assert result == "ok"
+        assert fn.call_count == 2
+        mock_sleep.assert_called_once_with(1)
+
+    @patch("time.sleep")
+    def test_should_succeed_after_multiple_transient_failures(self, mock_sleep):
+        fn = MagicMock(side_effect=[
+            TimeoutError("timeout"),
+            ConnectionError("conn"),
+            "ok",
+        ])
+        result = retry_with_backoff(fn, DEFAULT_CONFIG)
+        assert result == "ok"
+        assert fn.call_count == 3
+
+
+class TestRetryExhaustion:
+    @patch("time.sleep")
+    def test_should_raise_after_all_retries_exhausted(self, mock_sleep):
+        fn = MagicMock(side_effect=RateLimitError("429"))
+        with pytest.raises(RateLimitError):
+            retry_with_backoff(fn, DEFAULT_CONFIG)
+        assert fn.call_count == 4  # 1 initial + 3 retries
+
+    @patch("time.sleep")
+    def test_should_use_configured_backoff_times(self, mock_sleep):
+        fn = MagicMock(side_effect=RateLimitError("429"))
+        with pytest.raises(RateLimitError):
+            retry_with_backoff(fn, DEFAULT_CONFIG)
+        sleep_times = [c.args[0] for c in mock_sleep.call_args_list]
+        assert sleep_times == [1, 2, 4]
+
+
+class TestNonRetryable:
+    def test_should_raise_immediately_on_auth_error(self):
+        fn = MagicMock(side_effect=AuthenticationError("401"))
+        with pytest.raises(AuthenticationError):
+            retry_with_backoff(fn, DEFAULT_CONFIG)
+        assert fn.call_count == 1
+
+    def test_should_raise_immediately_on_invalid_request(self):
+        fn = MagicMock(side_effect=InvalidRequestError("400"))
+        with pytest.raises(InvalidRequestError):
+            retry_with_backoff(fn, DEFAULT_CONFIG)
+        assert fn.call_count == 1
+
+
+class TestRetryAfterHeader:
+    @patch("time.sleep")
+    def test_should_respect_retry_after_when_configured(self, mock_sleep):
+        err = RateLimitError("429", retry_after=30)
+        fn = MagicMock(side_effect=[err, "ok"])
+        result = retry_with_backoff(fn, DEFAULT_CONFIG)
+        assert result == "ok"
+        mock_sleep.assert_called_once_with(30)
+
+    @patch("time.sleep")
+    def test_should_ignore_retry_after_when_disabled(self, mock_sleep):
+        err = RateLimitError("429", retry_after=30)
+        config = {**DEFAULT_CONFIG, "respect_retry_after": False}
+        fn = MagicMock(side_effect=[err, "ok"])
+        result = retry_with_backoff(fn, config)
+        assert result == "ok"
+        mock_sleep.assert_called_once_with(1)
+
+
+class TestLogCallback:
+    @patch("time.sleep")
+    def test_should_log_retries(self, mock_sleep):
+        fn = MagicMock(side_effect=[RateLimitError("429"), "ok"])
+        log = MagicMock()
+        retry_with_backoff(fn, DEFAULT_CONFIG, log_callback=log)
+        log.assert_called()
+        log_msg = log.call_args_list[0].args[1]
+        assert "retry" in log_msg.lower() or "Retry" in log_msg

--- a/lightroom_tagger/core/test_vision_client.py
+++ b/lightroom_tagger/core/test_vision_client.py
@@ -1,0 +1,173 @@
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import openai as openai_sdk
+import pytest
+
+from lightroom_tagger.core.provider_errors import (
+    AuthenticationError,
+    ConnectionError,
+    InvalidRequestError,
+    ModelUnavailableError,
+    RateLimitError,
+    TimeoutError,
+)
+from lightroom_tagger.core.vision_client import compare_images, generate_description
+
+
+def _make_mock_client(response_text: str):
+    client = MagicMock()
+    choice = MagicMock()
+    choice.message.content = response_text
+    client.chat.completions.create.return_value = MagicMock(choices=[choice])
+    return client
+
+
+def _make_temp_image():
+    fd, path = tempfile.mkstemp(suffix=".jpg")
+    os.write(fd, b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00\xff\xd9")
+    os.close(fd)
+    return path
+
+
+@pytest.fixture()
+def temp_image():
+    path = _make_temp_image()
+    yield path
+    if os.path.exists(path):
+        os.unlink(path)
+
+
+class TestCompareImages:
+    def test_should_parse_json_confidence_response(self, temp_image):
+        client = _make_mock_client('{"confidence": 85, "reasoning": "same scene"}')
+        result = compare_images(client, "test-model", temp_image, temp_image)
+        assert result["confidence"] == 85
+        assert result["verdict"] == "SAME"
+        assert result["reasoning"] == "same scene"
+
+    def test_should_parse_low_confidence_as_different(self, temp_image):
+        client = _make_mock_client('{"confidence": 15, "reasoning": "different scenes"}')
+        result = compare_images(client, "test-model", temp_image, temp_image)
+        assert result["verdict"] == "DIFFERENT"
+
+    def test_should_parse_uncertain_range(self, temp_image):
+        client = _make_mock_client('{"confidence": 50, "reasoning": "unclear"}')
+        result = compare_images(client, "test-model", temp_image, temp_image)
+        assert result["verdict"] == "UNCERTAIN"
+
+    def test_should_send_two_images_in_message(self, temp_image):
+        client = _make_mock_client('{"confidence": 90, "reasoning": "same"}')
+        compare_images(client, "test-model", temp_image, temp_image)
+        call_args = client.chat.completions.create.call_args
+        content = call_args.kwargs["messages"][0]["content"]
+        image_parts = [p for p in content if p.get("type") == "image_url"]
+        assert len(image_parts) == 2
+
+    def test_should_use_provided_model(self, temp_image):
+        client = _make_mock_client('{"confidence": 90, "reasoning": "same"}')
+        compare_images(client, "my-custom-model", temp_image, temp_image)
+        call_args = client.chat.completions.create.call_args
+        assert call_args.kwargs["model"] == "my-custom-model"
+
+    def test_should_invoke_log_callback(self, temp_image):
+        client = _make_mock_client('{"confidence": 90, "reasoning": "same"}')
+        log = MagicMock()
+        compare_images(client, "test-model", temp_image, temp_image, log_callback=log)
+        log.assert_called()
+
+
+class TestGenerateDescription:
+    def test_should_return_raw_text(self, temp_image):
+        client = _make_mock_client('{"summary": "A landscape photo"}')
+        result = generate_description(client, "test-model", temp_image)
+        assert "landscape" in result
+
+    def test_should_send_one_image_in_message(self, temp_image):
+        client = _make_mock_client("some description text")
+        generate_description(client, "test-model", temp_image)
+        call_args = client.chat.completions.create.call_args
+        content = call_args.kwargs["messages"][0]["content"]
+        image_parts = [p for p in content if p.get("type") == "image_url"]
+        assert len(image_parts) == 1
+
+    def test_should_use_description_prompt(self, temp_image):
+        client = _make_mock_client("ok")
+        generate_description(client, "test-model", temp_image)
+        call_args = client.chat.completions.create.call_args
+        content = call_args.kwargs["messages"][0]["content"]
+        text_parts = [p for p in content if p.get("type") == "text"]
+        assert len(text_parts) == 1
+        assert "photo editor" in text_parts[0]["text"]
+
+
+class TestErrorMapping:
+    def _make_api_error(self, error_cls, status_code):
+        mock_response = MagicMock()
+        mock_response.status_code = status_code
+        mock_response.headers = {}
+        return error_cls("err", response=mock_response, body=None)
+
+    def test_should_map_rate_limit_error(self, temp_image):
+        client = MagicMock()
+        client.chat.completions.create.side_effect = self._make_api_error(
+            openai_sdk.RateLimitError, 429
+        )
+        with pytest.raises(RateLimitError):
+            compare_images(client, "m", temp_image, temp_image)
+
+    def test_should_map_auth_error(self, temp_image):
+        client = MagicMock()
+        client.chat.completions.create.side_effect = self._make_api_error(
+            openai_sdk.AuthenticationError, 401
+        )
+        with pytest.raises(AuthenticationError):
+            compare_images(client, "m", temp_image, temp_image)
+
+    def test_should_map_bad_request_error(self, temp_image):
+        client = MagicMock()
+        client.chat.completions.create.side_effect = self._make_api_error(
+            openai_sdk.BadRequestError, 400
+        )
+        with pytest.raises(InvalidRequestError):
+            compare_images(client, "m", temp_image, temp_image)
+
+    def test_should_map_timeout_error(self, temp_image):
+        client = MagicMock()
+        client.chat.completions.create.side_effect = openai_sdk.APITimeoutError(
+            request=MagicMock()
+        )
+        with pytest.raises(TimeoutError):
+            compare_images(client, "m", temp_image, temp_image)
+
+    def test_should_map_connection_error(self, temp_image):
+        client = MagicMock()
+        client.chat.completions.create.side_effect = openai_sdk.APIConnectionError(
+            request=MagicMock()
+        )
+        with pytest.raises(ConnectionError):
+            compare_images(client, "m", temp_image, temp_image)
+
+    def test_should_map_503_to_model_unavailable(self, temp_image):
+        client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 503
+        mock_response.headers = {}
+        client.chat.completions.create.side_effect = openai_sdk.APIStatusError(
+            "overloaded", response=mock_response, body=None
+        )
+        with pytest.raises(ModelUnavailableError):
+            compare_images(client, "m", temp_image, temp_image)
+
+    def test_should_extract_retry_after_header(self, temp_image):
+        client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 429
+        mock_response.headers = {"retry-after": "30"}
+        client.chat.completions.create.side_effect = openai_sdk.RateLimitError(
+            "rate limited", response=mock_response, body=None
+        )
+        with pytest.raises(RateLimitError) as exc_info:
+            compare_images(client, "m", temp_image, temp_image)
+        assert exc_info.value.retry_after == 30.0

--- a/lightroom_tagger/core/vision_client.py
+++ b/lightroom_tagger/core/vision_client.py
@@ -1,0 +1,157 @@
+"""Unified vision client functions using OpenAI-compatible API.
+
+Two plain functions — ``compare_images`` and ``generate_description`` — that
+accept any ``openai.OpenAI`` client (Ollama, NVIDIA NIM, OpenRouter) and a
+model identifier.  All provider-specific SDK errors are mapped into our
+``ProviderError`` hierarchy so callers never depend on the SDK directly.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+from typing import Any, Callable
+
+import openai as openai_sdk
+
+from lightroom_tagger.core.analyzer import (
+    build_description_prompt,
+    parse_vision_response,
+)
+from lightroom_tagger.core.provider_errors import (
+    AuthenticationError,
+    ConnectionError,
+    ContextLengthError,
+    InvalidRequestError,
+    ModelUnavailableError,
+    ProviderError,
+    RateLimitError,
+    TimeoutError,
+)
+
+COMPARISON_PROMPT = (
+    "You are comparing two images to determine if they depict the same photograph "
+    "(possibly with different crops, compression, or processing).\n\n"
+    "Respond with ONLY valid JSON, no other text:\n"
+    '{"confidence": <0-100>, "reasoning": "<one sentence>"}\n\n'
+    "confidence: 0 = definitely different photos, 100 = definitely the same photo.\n"
+    "Focus on semantic content (subject, scene, composition), not pixel-level differences."
+)
+
+LogCallback = Callable[[str, str], None] | None
+
+
+def _encode_image(path: str) -> str:
+    with open(path, "rb") as f:
+        return base64.b64encode(f.read()).decode("utf-8")
+
+
+def _image_url_part(b64: str) -> dict[str, Any]:
+    return {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{b64}"}}
+
+
+def _map_openai_error(exc: Exception) -> ProviderError:
+    """Map openai SDK exceptions to our ProviderError hierarchy."""
+    retry_after = None
+    if hasattr(exc, "response") and exc.response is not None:
+        raw = exc.response.headers.get("retry-after")
+        if raw:
+            try:
+                retry_after = float(raw)
+            except (ValueError, TypeError):
+                pass
+
+    if isinstance(exc, openai_sdk.RateLimitError):
+        return RateLimitError(str(exc), retry_after=retry_after)
+    if isinstance(exc, openai_sdk.AuthenticationError):
+        return AuthenticationError(str(exc))
+    if isinstance(exc, openai_sdk.BadRequestError):
+        msg = str(exc).lower()
+        if "context length" in msg or "too many tokens" in msg or "maximum" in msg:
+            return ContextLengthError(str(exc))
+        return InvalidRequestError(str(exc))
+    if isinstance(exc, openai_sdk.APITimeoutError):
+        return TimeoutError(str(exc))
+    if isinstance(exc, openai_sdk.APIConnectionError):
+        return ConnectionError(str(exc))
+    if isinstance(exc, openai_sdk.APIStatusError):
+        status = getattr(exc.response, "status_code", 0) if exc.response else 0
+        if status == 503:
+            return ModelUnavailableError(str(exc))
+        return ProviderError(str(exc))
+
+    return ProviderError(str(exc))
+
+
+def compare_images(
+    client: openai_sdk.OpenAI,
+    model: str,
+    local_path: str,
+    insta_path: str,
+    log_callback: LogCallback = None,
+) -> dict[str, Any]:
+    """Compare two images via chat completions. Returns parsed result dict."""
+    local_b64 = _encode_image(local_path)
+    insta_b64 = _encode_image(insta_path)
+
+    try:
+        response = client.chat.completions.create(
+            model=model,
+            messages=[{
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": COMPARISON_PROMPT},
+                    _image_url_part(local_b64),
+                    _image_url_part(insta_b64),
+                ],
+            }],
+            max_tokens=256,
+        )
+    except Exception as exc:
+        raise _map_openai_error(exc) from exc
+
+    raw = response.choices[0].message.content or ""
+    result = parse_vision_response(raw)
+
+    if log_callback:
+        local_name = os.path.basename(local_path)
+        insta_name = os.path.basename(insta_path)
+        log_callback(
+            "debug",
+            f"[vision] {local_name} vs {insta_name} -> {result['verdict']} "
+            f"({result['confidence']}%) model={model}",
+        )
+
+    return result
+
+
+def generate_description(
+    client: openai_sdk.OpenAI,
+    model: str,
+    image_path: str,
+    log_callback: LogCallback = None,
+) -> str:
+    """Generate a structured description for a single image. Returns raw text."""
+    img_b64 = _encode_image(image_path)
+
+    try:
+        response = client.chat.completions.create(
+            model=model,
+            messages=[{
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": build_description_prompt()},
+                    _image_url_part(img_b64),
+                ],
+            }],
+            max_tokens=2048,
+        )
+    except Exception as exc:
+        raise _map_openai_error(exc) from exc
+
+    raw = response.choices[0].message.content or ""
+
+    if log_callback:
+        log_callback("debug", f"[describe] {os.path.basename(image_path)} -> {len(raw)} chars")
+
+    return raw

--- a/lightroom_tagger/core/vision_client.py
+++ b/lightroom_tagger/core/vision_client.py
@@ -50,8 +50,22 @@ def _image_url_part(b64: str) -> dict[str, Any]:
     return {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{b64}"}}
 
 
-def _map_openai_error(exc: Exception) -> ProviderError:
-    """Map openai SDK exceptions to our ProviderError hierarchy."""
+def _map_openai_error(
+    exc: Exception,
+    provider: str | None = None,
+    model: str | None = None,
+) -> ProviderError:
+    """Map openai SDK exceptions to our ProviderError hierarchy.
+
+    Parameters
+    ----------
+    exc:
+        The original SDK exception.
+    provider:
+        Provider id to attach as context on the mapped error.
+    model:
+        Model name to attach as context on the mapped error.
+    """
     retry_after = None
     if hasattr(exc, "response") and exc.response is not None:
         raw = exc.response.headers.get("retry-after")
@@ -62,25 +76,25 @@ def _map_openai_error(exc: Exception) -> ProviderError:
                 pass
 
     if isinstance(exc, openai_sdk.RateLimitError):
-        return RateLimitError(str(exc), retry_after=retry_after)
+        return RateLimitError(str(exc), provider=provider, model=model, retry_after=retry_after)
     if isinstance(exc, openai_sdk.AuthenticationError):
-        return AuthenticationError(str(exc))
+        return AuthenticationError(str(exc), provider=provider, model=model)
     if isinstance(exc, openai_sdk.BadRequestError):
         msg = str(exc).lower()
         if "context length" in msg or "too many tokens" in msg or "maximum" in msg:
-            return ContextLengthError(str(exc))
-        return InvalidRequestError(str(exc))
+            return ContextLengthError(str(exc), provider=provider, model=model)
+        return InvalidRequestError(str(exc), provider=provider, model=model)
     if isinstance(exc, openai_sdk.APITimeoutError):
-        return TimeoutError(str(exc))
+        return TimeoutError(str(exc), provider=provider, model=model)
     if isinstance(exc, openai_sdk.APIConnectionError):
-        return ConnectionError(str(exc))
+        return ConnectionError(str(exc), provider=provider, model=model)
     if isinstance(exc, openai_sdk.APIStatusError):
         status = getattr(exc.response, "status_code", 0) if exc.response else 0
         if status == 503:
-            return ModelUnavailableError(str(exc))
-        return ProviderError(str(exc))
+            return ModelUnavailableError(str(exc), provider=provider, model=model)
+        return ProviderError(str(exc), provider=provider, model=model)
 
-    return ProviderError(str(exc))
+    return ProviderError(str(exc), provider=provider, model=model)
 
 
 def compare_images(
@@ -108,7 +122,7 @@ def compare_images(
             max_tokens=256,
         )
     except Exception as exc:
-        raise _map_openai_error(exc) from exc
+        raise _map_openai_error(exc, provider=getattr(client, '_provider_id', None), model=model) from exc
 
     raw = response.choices[0].message.content or ""
     result = parse_vision_response(raw)
@@ -147,7 +161,7 @@ def generate_description(
             max_tokens=2048,
         )
     except Exception as exc:
-        raise _map_openai_error(exc) from exc
+        raise _map_openai_error(exc, provider=getattr(client, '_provider_id', None), model=model) from exc
 
     raw = response.choices[0].message.content or ""
 

--- a/lightroom_tagger/scripts/match_instagram_dump.py
+++ b/lightroom_tagger/scripts/match_instagram_dump.py
@@ -38,7 +38,9 @@ def match_dump_media(db, threshold: float = 0.7, batch_size: int = None,
                      progress_callback=None, log_callback=None,
                      weights: dict = None, media_key: str = None,
                      force_descriptions: bool = False,
-                     force_reprocess: bool = False) -> tuple:
+                     force_reprocess: bool = False,
+                     provider_id: str = None,
+                     provider_model: str = None) -> tuple:
     """Match Instagram dump media against catalog images using cascade filtering.
 
     Args:
@@ -145,7 +147,9 @@ def match_dump_media(db, threshold: float = 0.7, batch_size: int = None,
             desc_weight=weights.get('description', 0.3),
             vision_weight=weights.get('vision', 0.3),
             threshold=threshold,
-            log_callback=log_callback
+            log_callback=log_callback,
+            provider_id=provider_id,
+            model=provider_model,
         )
 
         above_threshold = [r for r in results if r['total_score'] >= threshold]

--- a/lightroom_tagger/scripts/match_instagram_dump.py
+++ b/lightroom_tagger/scripts/match_instagram_dump.py
@@ -39,8 +39,8 @@ def match_dump_media(db, threshold: float = 0.7, batch_size: int = None,
                      weights: dict = None, media_key: str = None,
                      force_descriptions: bool = False,
                      force_reprocess: bool = False,
-                     provider_id: str = None,
-                     provider_model: str = None) -> tuple:
+                     provider_id: str | None = None,
+                     provider_model: str | None = None) -> tuple:
     """Match Instagram dump media against catalog images using cascade filtering.
 
     Args:
@@ -52,6 +52,8 @@ def match_dump_media(db, threshold: float = 0.7, batch_size: int = None,
         last_months: Filter Instagram by last N months
         media_key: If set, process only this Instagram dump row (ignores batch/date filters)
         force_reprocess: If True, include already-processed images in the batch
+        provider_id: Optional vision provider id (registry key); None uses defaults
+        provider_model: Optional model id for that provider; None uses provider default
         progress_callback: Optional callback(current, total, message) for progress updates
         log_callback: Optional callback(level, message) for detailed logging
         weights: Optional dict with 'phash', 'description', 'vision' keys for scoring weights


### PR DESCRIPTION
## SUMMARY

Multi-provider vision pipeline :)
Adds support for Ollama, NVIDIA NIM, and OpenRouter as interchangeable vision providers — all using the OpenAI-compatible API. When one provider fails, it automatically cascades to the next. No more hardcoded Ollama-only.

## DETAILS

**Core pipeline (new modules):**
- `vision_client.py` — `compare_images()` / `generate_description()` via OpenAI SDK with error mapping to our exception hierarchy
- `retry.py` — configurable exponential backoff, respects `retry-after` headers, skips non-retryable errors (auth, bad request)
- `fallback.py` — `FallbackDispatcher` tries the selected provider, then cascades through fallback order on retryable failures
- `provider_registry.py` — loads `providers.json` config (3 providers, 11 models), auto-discovers Ollama models via `/api/tags`, returns configured `openai.OpenAI` clients
- `provider_errors.py` — exception hierarchy: `RateLimitError`, `TimeoutError`, `ConnectionError`, `ModelUnavailableError` (retryable) vs `AuthenticationError`, `InvalidRequestError` (not retryable)

**Backend wiring:**
- `analyzer.py`, `matcher.py`, `description_service.py` accept optional `provider_id`/`model` params — backward compatible with legacy Ollama path
- Rate-limit circuit breaker in matcher: 3 consecutive 429s = skip remaining candidates
- Job handlers thread `provider_id`/`provider_model` from job metadata
- Descriptions endpoint returns structured 429/401/503 errors
- New `/api/providers/` blueprint: list providers, models, fallback order, defaults

**Frontend:**
- `ProvidersPage` with expandable `ProviderCard` (model table) and `FallbackOrderPanel`
- `ProviderModelSelect` reusable dropdown
- `useProviders` / `useProviderModels` hooks
- `classifyApiError` utility + `Alert` component for error feedback on description generation
- All strings in constants, descriptive variable names throughout

**Tests:** 49 new tests across 5 test files (provider_errors, provider_registry, vision_client, retry, fallback, providers_api). 149 core + 56 backend + 96 frontend all passing.

## DEVELOPER IMPACT

Set `NVIDIA_NIM_API_KEY` or `OPENROUTER_API_KEY` in `.env` to enable cloud providers. Without them, only Ollama (local) is used — same behavior as before. Jobs and single-image description can now accept `provider_id` / `provider_model` in metadata/request body.

## TESTING

- 149 core tests passing (includes 49 new)
- 56 backend tests passing (6 new, 2 pre-existing failures unchanged)
- 96 frontend tests passing (0 regressions)
- TypeScript builds clean

## DOCUMENTATION

Updated `.env.example` with `NVIDIA_NIM_API_KEY` and `OPENROUTER_API_KEY`

## PIC

![providers go brrr](https://i.imgflip.com/2k48t0.jpg)