### PR TITLE
feat: wire provider selection, editable fallback, user model management

### DIFF
--- a/apps/visualizer/backend/api/providers.py
+++ b/apps/visualizer/backend/api/providers.py
@@ -66,10 +66,15 @@ def models(provider_id: str):
 
     if request.method == "GET":
         models_list = registry.list_models(provider_id)
+        existing_model_ids = {model_entry["id"] for model_entry in models_list}
         user_models = get_user_models(current_app.db, provider_id)
         for user_model in user_models:
+            user_model_id = user_model["model_id"]
+            if user_model_id in existing_model_ids:
+                continue
+            existing_model_ids.add(user_model_id)
             models_list.append({
-                "id": user_model["model_id"],
+                "id": user_model_id,
                 "name": user_model["model_name"],
                 "vision": bool(user_model["vision"]),
                 "source": "user",

--- a/apps/visualizer/backend/api/providers.py
+++ b/apps/visualizer/backend/api/providers.py
@@ -82,25 +82,37 @@ def models(provider_id: str):
         return jsonify(models_list)
 
     data = request.json
-    if not data or "id" not in data or "name" not in data:
+    if not data:
         return jsonify({"error": "id and name are required"}), 400
+
+    model_id = data.get("id")
+    model_name = data.get("name")
+    if not isinstance(model_id, str) or not model_id.strip():
+        return jsonify({"error": "id must be a non-empty string"}), 400
+    if not isinstance(model_name, str) or not model_name.strip():
+        return jsonify({"error": "name must be a non-empty string"}), 400
+
+    vision = data.get("vision", True)
+    if "vision" in data and not isinstance(vision, bool):
+        return jsonify({"error": "vision must be a boolean"}), 400
+
     try:
         add_user_model(
             current_app.db,
             provider_id,
-            data["id"],
-            data["name"],
-            data.get("vision", True),
+            model_id,
+            model_name,
+            vision,
         )
     except sqlite3.IntegrityError:
         return jsonify(
-            {"error": f"Model {data['id']} already exists for {provider_id}"}
+            {"error": f"Model {model_id} already exists for {provider_id}"}
         ), 409
     return (
         jsonify({
-            "id": data["id"],
-            "name": data["name"],
-            "vision": data.get("vision", True),
+            "id": model_id,
+            "name": model_name,
+            "vision": vision,
             "source": "user",
         }),
         201,

--- a/apps/visualizer/backend/api/providers.py
+++ b/apps/visualizer/backend/api/providers.py
@@ -1,6 +1,9 @@
 """Providers API — list providers, models, manage fallback order."""
 
-from flask import Blueprint, jsonify
+import sqlite3
+
+from database import add_user_model, delete_user_model, get_user_models
+from flask import Blueprint, current_app, jsonify, request
 
 from lightroom_tagger.core.provider_registry import ProviderRegistry
 
@@ -17,23 +20,83 @@ def list_providers():
     return jsonify(registry.list_providers())
 
 
-@bp.route("/<provider_id>/models", methods=["GET"])
-def list_models(provider_id: str):
+@bp.route("/fallback-order", methods=["GET", "PUT"])
+def fallback_order():
     registry = _get_registry()
+    if request.method == "GET":
+        return jsonify({"order": registry.fallback_order})
+    data = request.json
+    if not data or "order" not in data:
+        return jsonify({"error": "order is required"}), 400
     try:
-        models = registry.list_models(provider_id)
-    except KeyError:
-        return jsonify({"error": f"Unknown provider: {provider_id}"}), 404
-    return jsonify(models)
-
-
-@bp.route("/fallback-order", methods=["GET"])
-def get_fallback_order():
-    registry = _get_registry()
+        registry.update_fallback_order(data["order"])
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
     return jsonify({"order": registry.fallback_order})
 
 
-@bp.route("/defaults", methods=["GET"])
-def get_defaults():
+@bp.route("/defaults", methods=["GET", "PUT"])
+def defaults():
     registry = _get_registry()
+    if request.method == "GET":
+        return jsonify(registry.defaults)
+    data = request.json
+    if not data:
+        return jsonify({"error": "body is required"}), 400
+    try:
+        registry.update_defaults(data)
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
     return jsonify(registry.defaults)
+
+
+@bp.route("/<provider_id>/models/<path:model_id>", methods=["DELETE"])
+def delete_model(provider_id: str, model_id: str):
+    deleted = delete_user_model(current_app.db, provider_id, model_id)
+    if not deleted:
+        return jsonify({"error": "Model not found or not user-added"}), 404
+    return jsonify({"deleted": True})
+
+
+@bp.route("/<provider_id>/models", methods=["GET", "POST"])
+def models(provider_id: str):
+    registry = _get_registry()
+    if provider_id not in [provider["id"] for provider in registry.list_providers()]:
+        return jsonify({"error": f"Unknown provider: {provider_id}"}), 404
+
+    if request.method == "GET":
+        models_list = registry.list_models(provider_id)
+        user_models = get_user_models(current_app.db, provider_id)
+        for user_model in user_models:
+            models_list.append({
+                "id": user_model["model_id"],
+                "name": user_model["model_name"],
+                "vision": bool(user_model["vision"]),
+                "source": "user",
+            })
+        return jsonify(models_list)
+
+    data = request.json
+    if not data or "id" not in data or "name" not in data:
+        return jsonify({"error": "id and name are required"}), 400
+    try:
+        add_user_model(
+            current_app.db,
+            provider_id,
+            data["id"],
+            data["name"],
+            data.get("vision", True),
+        )
+    except sqlite3.IntegrityError:
+        return jsonify(
+            {"error": f"Model {data['id']} already exists for {provider_id}"}
+        ), 409
+    return (
+        jsonify({
+            "id": data["id"],
+            "name": data["name"],
+            "vision": data.get("vision", True),
+            "source": "user",
+        }),
+        201,
+    )

--- a/apps/visualizer/backend/api/system.py
+++ b/apps/visualizer/backend/api/system.py
@@ -1,9 +1,8 @@
 import os
-import subprocess
 import sys
 
 import config
-from flask import Blueprint, jsonify
+from flask import Blueprint, current_app, has_app_context, jsonify
 from lightroom_tagger.core.database import init_database
 
 # Add project root for lightroom_tagger imports
@@ -18,46 +17,72 @@ def get_status():
 
 @bp.route('/vision-models', methods=['GET'])
 def get_vision_models():
-    """Get available vision models from Ollama."""
+    """Get available vision models from all providers (registry + optional user DB rows)."""
     try:
-        # Get list of vision-capable models from Ollama
-        result = subprocess.run(
-            ['ollama', 'list'],
-            capture_output=True,
-            text=True,
-            timeout=10
-        )
-        if result.returncode != 0:
-            # Fallback to common vision models
-            return jsonify({
-                'models': [
-                    {'name': 'gemma3:27b', 'default': True},
-                    {'name': 'gemma3:4b', 'default': False},
-                ],
-                'fallback': True
-            })
+        from lightroom_tagger.core.provider_registry import ProviderRegistry
 
-        models = []
-        default_model = config.vision_model if hasattr(config, 'vision_model') else 'gemma3:27b'
-        for line in result.stdout.strip().split('\n'):
-            if line and not line.startswith('NAME'):
-                model_name = line.split()[0]
-                models.append({
-                    'name': model_name,
-                    'default': model_name == default_model
+        registry = ProviderRegistry()
+        defaults = registry.defaults
+        default_comparison = defaults.get("vision_comparison", {})
+        default_provider = default_comparison.get("provider", "ollama")
+        default_model = default_comparison.get("model")
+
+        all_models = []
+        for provider in registry.list_providers():
+            if not provider["available"]:
+                continue
+            try:
+                models = registry.list_models(provider["id"])
+            except Exception:
+                continue
+            for model in models:
+                if not model.get("vision"):
+                    continue
+                model_name = model["id"]
+                is_default = (
+                    provider["id"] == default_provider
+                    and (default_model is None or default_model == model_name)
+                    and not any(m.get("default") for m in all_models)
+                )
+                all_models.append({
+                    "name": model_name,
+                    "provider_id": provider["id"],
+                    "default": is_default,
                 })
 
-        return jsonify({
-            'models': models,
-            'fallback': False
-        })
+        if has_app_context():
+            db = getattr(current_app, "db", None)
+            if db is not None:
+                from database import get_user_models
 
+                seen = {(entry["provider_id"], entry["name"]) for entry in all_models}
+                for user_model in get_user_models(db):
+                    if not user_model.get("vision"):
+                        continue
+                    key = (user_model["provider_id"], user_model["model_id"])
+                    if key in seen:
+                        continue
+                    all_models.append({
+                        "name": user_model["model_id"],
+                        "provider_id": user_model["provider_id"],
+                        "default": False,
+                    })
+                    seen.add(key)
+
+        if not all_models:
+            return jsonify({
+                "models": [{"name": "gemma3:27b", "default": True}],
+                "fallback": True,
+            })
+
+        if not any(m["default"] for m in all_models):
+            all_models[0]["default"] = True
+
+        return jsonify({"models": all_models, "fallback": False})
     except Exception:
         return jsonify({
-            'models': [
-                {'name': 'gemma3:27b', 'default': True},
-            ],
-            'fallback': True
+            "models": [{"name": "gemma3:27b", "default": True}],
+            "fallback": True,
         })
 
 @bp.route('/stats', methods=['GET'])

--- a/apps/visualizer/backend/api/system.py
+++ b/apps/visualizer/backend/api/system.py
@@ -1,9 +1,12 @@
+import logging
 import os
 import sys
 
 import config
 from flask import Blueprint, current_app, has_app_context, jsonify
 from lightroom_tagger.core.database import init_database
+
+logger = logging.getLogger(__name__)
 
 # Add project root for lightroom_tagger imports
 _PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
@@ -34,6 +37,7 @@ def get_vision_models():
             try:
                 models = registry.list_models(provider["id"])
             except Exception:
+                logger.exception("Failed to list models for provider %s", provider["id"])
                 continue
             for model in models:
                 if not model.get("vision"):
@@ -42,7 +46,7 @@ def get_vision_models():
                 is_default = (
                     provider["id"] == default_provider
                     and (default_model is None or default_model == model_name)
-                    and not any(m.get("default") for m in all_models)
+                    and not any(entry.get("default") for entry in all_models)
                 )
                 all_models.append({
                     "name": model_name,
@@ -75,7 +79,7 @@ def get_vision_models():
                 "fallback": True,
             })
 
-        if not any(m["default"] for m in all_models):
+        if not any(entry["default"] for entry in all_models):
             all_models[0]["default"] = True
 
         return jsonify({"models": all_models, "fallback": False})

--- a/apps/visualizer/backend/api/system.py
+++ b/apps/visualizer/backend/api/system.py
@@ -84,6 +84,7 @@ def get_vision_models():
 
         return jsonify({"models": all_models, "fallback": False})
     except Exception:
+        logger.exception("Failed to load vision models from registry")
         return jsonify({
             "models": [{"name": "gemma3:27b", "default": True}],
             "fallback": True,

--- a/apps/visualizer/backend/database.py
+++ b/apps/visualizer/backend/database.py
@@ -50,6 +50,15 @@ def init_db(db_path: str) -> sqlite3.Connection:
     """)
     conn.execute("CREATE INDEX IF NOT EXISTS idx_jobs_status ON jobs(status)")
     conn.execute("CREATE INDEX IF NOT EXISTS idx_jobs_type ON jobs(type)")
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS provider_models (
+            provider_id TEXT NOT NULL,
+            model_id TEXT NOT NULL,
+            model_name TEXT NOT NULL,
+            vision INTEGER DEFAULT 1,
+            PRIMARY KEY (provider_id, model_id)
+        )
+    """)
     conn.commit()
     return conn
 
@@ -152,3 +161,58 @@ def get_pending_jobs(db: sqlite3.Connection) -> list:
     """Get all pending jobs."""
     rows = db.execute("SELECT * FROM jobs WHERE status = 'pending'").fetchall()
     return [_deserialize_job(r) for r in rows]
+
+
+def get_user_models(
+    db: sqlite3.Connection, provider_id: str | None = None
+) -> list[dict]:
+    """List user-added provider models, optionally filtered by provider."""
+    if provider_id is not None:
+        rows = db.execute(
+            """
+            SELECT provider_id, model_id, model_name, vision
+            FROM provider_models
+            WHERE provider_id = ?
+            ORDER BY model_id
+            """,
+            (provider_id,),
+        ).fetchall()
+    else:
+        rows = db.execute(
+            """
+            SELECT provider_id, model_id, model_name, vision
+            FROM provider_models
+            ORDER BY provider_id, model_id
+            """
+        ).fetchall()
+    return list(rows)
+
+
+def add_user_model(
+    db: sqlite3.Connection,
+    provider_id: str,
+    model_id: str,
+    model_name: str,
+    vision: bool = True,
+) -> None:
+    """Insert a user-defined model row. Raises sqlite3.IntegrityError on duplicate."""
+    db.execute(
+        """
+        INSERT INTO provider_models (provider_id, model_id, model_name, vision)
+        VALUES (?, ?, ?, ?)
+        """,
+        (provider_id, model_id, model_name, 1 if vision else 0),
+    )
+    db.commit()
+
+
+def delete_user_model(
+    db: sqlite3.Connection, provider_id: str, model_id: str
+) -> bool:
+    """Delete a user-defined model. Returns True if a row was removed."""
+    cur = db.execute(
+        "DELETE FROM provider_models WHERE provider_id = ? AND model_id = ?",
+        (provider_id, model_id),
+    )
+    db.commit()
+    return cur.rowcount > 0

--- a/apps/visualizer/backend/database.py
+++ b/apps/visualizer/backend/database.py
@@ -186,7 +186,9 @@ def get_user_models(
             """
         ).fetchall()
     return [
-        user_model_row if isinstance(user_model_row, dict) else dict(user_model_row)
+        user_model_row
+        if isinstance(user_model_row, dict)
+        else {key: user_model_row[key] for key in user_model_row.keys()}
         for user_model_row in rows
     ]
 

--- a/apps/visualizer/backend/database.py
+++ b/apps/visualizer/backend/database.py
@@ -185,7 +185,10 @@ def get_user_models(
             ORDER BY provider_id, model_id
             """
         ).fetchall()
-    return list(rows)
+    return [
+        user_model_row if isinstance(user_model_row, dict) else dict(user_model_row)
+        for user_model_row in rows
+    ]
 
 
 def add_user_model(

--- a/apps/visualizer/backend/tests/test_db_utils.py
+++ b/apps/visualizer/backend/tests/test_db_utils.py
@@ -8,12 +8,12 @@ class TestWithDbDecorator:
     """Tests for with_db decorator."""
 
     @patch('utils.db.os.path.exists')
-    @patch('utils.db.TinyDB')
-    def test_with_db_when_file_exists(self, mock_tinydb, mock_exists):
+    @patch('utils.db.init_database')
+    def test_with_db_when_file_exists(self, mock_init_database, mock_exists):
         """Test that decorator provides db when file exists."""
         mock_exists.return_value = True
         mock_db = MagicMock()
-        mock_tinydb.return_value = mock_db
+        mock_init_database.return_value = mock_db
 
         @with_db
         def test_handler(db):
@@ -21,7 +21,6 @@ class TestWithDbDecorator:
 
         result = test_handler()
 
-        # Result should be a tuple (response, status_code)
         assert len(result) == 2
         mock_db.close.assert_called_once()
 
@@ -36,5 +35,4 @@ class TestWithDbDecorator:
 
         result = test_handler()
 
-        # Result should be a response tuple
         assert len(result) == 2

--- a/apps/visualizer/backend/tests/test_jobs_api.py
+++ b/apps/visualizer/backend/tests/test_jobs_api.py
@@ -43,10 +43,14 @@ def test_get_job(client):
     assert response.json['type'] == 'vision_match'
 
 def test_get_active_jobs(client):
+    response = client.get('/api/jobs/active')
+    assert response.status_code == 200
+    assert len(response.json) == 0
+
     client.post('/api/jobs/',
         json={'type': 'vision_match', 'metadata': {}}
     )
 
     response = client.get('/api/jobs/active')
     assert response.status_code == 200
-    assert len(response.json) == 0  # No running jobs yet
+    assert len(response.json) == 1

--- a/apps/visualizer/backend/tests/test_providers_api.py
+++ b/apps/visualizer/backend/tests/test_providers_api.py
@@ -1,5 +1,5 @@
-import os
-from unittest.mock import patch
+import sqlite3
+from unittest.mock import PropertyMock, patch
 
 import pytest
 from app import create_app
@@ -9,8 +9,24 @@ from app import create_app
 def client():
     app = create_app()
     app.config["TESTING"] = True
-    with app.test_client() as c:
-        yield c
+    memory_db = sqlite3.connect(":memory:")
+    memory_db.row_factory = sqlite3.Row
+    memory_db.execute(
+        """
+        CREATE TABLE provider_models (
+            provider_id TEXT NOT NULL,
+            model_id TEXT NOT NULL,
+            model_name TEXT NOT NULL,
+            vision INTEGER DEFAULT 1,
+            PRIMARY KEY (provider_id, model_id)
+        )
+        """
+    )
+    memory_db.commit()
+    app.db = memory_db
+    with app.test_client() as test_client:
+        yield test_client
+    memory_db.close()
 
 
 class TestListProviders:
@@ -18,7 +34,7 @@ class TestListProviders:
         resp = client.get("/api/providers/")
         assert resp.status_code == 200
         data = resp.get_json()
-        ids = [p["id"] for p in data]
+        ids = [provider["id"] for provider in data]
         assert "ollama" in ids
         assert "nvidia_nim" in ids
         assert "openrouter" in ids
@@ -26,7 +42,7 @@ class TestListProviders:
     def test_should_include_availability_status(self, client):
         resp = client.get("/api/providers/")
         data = resp.get_json()
-        provider_map = {p["id"]: p for p in data}
+        provider_map = {provider["id"]: provider for provider in data}
         assert "available" in provider_map["ollama"]
 
 
@@ -35,7 +51,7 @@ class TestListModels:
         resp = client.get("/api/providers/nvidia_nim/models")
         assert resp.status_code == 200
         data = resp.get_json()
-        model_ids = [m["id"] for m in data]
+        model_ids = [model["id"] for model in data]
         assert "meta/llama-4-maverick-17b-128e-instruct" in model_ids
 
     def test_should_return_404_for_unknown_provider(self, client):
@@ -50,6 +66,51 @@ class TestFallbackOrder:
         data = resp.get_json()
         assert data["order"] == ["ollama", "nvidia_nim", "openrouter"]
 
+    def test_put_fallback_order_should_update_order(self, client):
+        from lightroom_tagger.core.provider_registry import ProviderRegistry
+
+        expected_order = ["nvidia_nim", "ollama", "openrouter"]
+
+        def capture_order(new_order):
+            shared_order[:] = list(new_order)
+
+        shared_order = list(expected_order)
+
+        with patch.object(
+            ProviderRegistry,
+            "fallback_order",
+            new_callable=PropertyMock,
+            return_value=shared_order,
+        ):
+            with patch.object(
+                ProviderRegistry, "update_fallback_order", side_effect=capture_order
+            ):
+                resp = client.put(
+                    "/api/providers/fallback-order",
+                    json={"order": expected_order},
+                )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["order"] == expected_order
+
+    def test_put_fallback_order_should_reject_empty_body(self, client):
+        resp = client.put("/api/providers/fallback-order", json={})
+        assert resp.status_code == 400
+
+    def test_put_fallback_order_should_reject_unknown_providers(self, client):
+        from lightroom_tagger.core.provider_registry import ProviderRegistry
+
+        with patch.object(
+            ProviderRegistry,
+            "update_fallback_order",
+            side_effect=ValueError("Unknown provider id(s): ['not_a_provider']"),
+        ):
+            resp = client.put(
+                "/api/providers/fallback-order",
+                json={"order": ["not_a_provider"]},
+            )
+        assert resp.status_code == 400
+
 
 class TestDefaults:
     def test_should_return_defaults(self, client):
@@ -58,3 +119,113 @@ class TestDefaults:
         data = resp.get_json()
         assert data["vision_comparison"]["provider"] == "ollama"
         assert data["description"]["provider"] == "ollama"
+
+    def test_put_defaults_should_update_defaults(self, client):
+        from lightroom_tagger.core.provider_registry import ProviderRegistry
+
+        merged_defaults = {
+            "vision_comparison": {"provider": "ollama", "model": "gemma3:27b"},
+            "description": {"provider": "ollama"},
+        }
+
+        def merge_defaults(incoming: dict) -> None:
+            merged_defaults.update(incoming)
+
+        with patch.object(
+            ProviderRegistry,
+            "defaults",
+            new_callable=PropertyMock,
+            return_value=merged_defaults,
+        ):
+            with patch.object(
+                ProviderRegistry, "update_defaults", side_effect=merge_defaults
+            ):
+                resp = client.put(
+                    "/api/providers/defaults",
+                    json={
+                        "vision_comparison": {
+                            "provider": "ollama",
+                            "model": "gemma3:27b",
+                        }
+                    },
+                )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["vision_comparison"]["provider"] == "ollama"
+        assert data["vision_comparison"]["model"] == "gemma3:27b"
+
+    def test_put_defaults_should_reject_empty_body(self, client):
+        resp = client.put("/api/providers/defaults", json={})
+        assert resp.status_code == 400
+        resp_null_json = client.put(
+            "/api/providers/defaults",
+            data="null",
+            content_type="application/json",
+        )
+        assert resp_null_json.status_code == 400
+
+    def test_put_defaults_should_reject_invalid_key(self, client):
+        from lightroom_tagger.core.provider_registry import ProviderRegistry
+
+        with patch.object(
+            ProviderRegistry,
+            "update_defaults",
+            side_effect=ValueError("Unknown defaults key: 'bad_key'"),
+        ):
+            resp = client.put(
+                "/api/providers/defaults",
+                json={"bad_key": {"provider": "ollama"}},
+            )
+        assert resp.status_code == 400
+
+
+class TestUserModels:
+    def test_post_model_should_create_user_model(self, client):
+        with patch("api.providers.add_user_model") as add_user_model_mock:
+            resp = client.post(
+                "/api/providers/ollama/models",
+                json={
+                    "id": "test-model",
+                    "name": "Test Model",
+                    "vision": True,
+                },
+            )
+        assert resp.status_code == 201
+        data = resp.get_json()
+        assert data["id"] == "test-model"
+        assert data["name"] == "Test Model"
+        assert data["vision"] is True
+        assert data["source"] == "user"
+        add_user_model_mock.assert_called_once()
+
+    def test_post_model_should_reject_missing_fields(self, client):
+        resp = client.post(
+            "/api/providers/ollama/models",
+            json={"name": "No Id Model"},
+        )
+        assert resp.status_code == 400
+
+    def test_post_model_should_reject_duplicate(self, client):
+        with patch("api.providers.add_user_model") as add_user_model_mock:
+            add_user_model_mock.side_effect = sqlite3.IntegrityError("UNIQUE constraint")
+            resp = client.post(
+                "/api/providers/ollama/models",
+                json={
+                    "id": "dup",
+                    "name": "Dup",
+                    "vision": True,
+                },
+            )
+        assert resp.status_code == 409
+
+    def test_delete_model_should_remove_user_model(self, client):
+        with patch("api.providers.delete_user_model", return_value=True) as delete_mock:
+            resp = client.delete("/api/providers/ollama/models/test-model")
+        assert resp.status_code == 200
+        assert resp.get_json() == {"deleted": True}
+        delete_mock.assert_called_once()
+
+    def test_delete_model_should_return_404_for_missing(self, client):
+        with patch("api.providers.delete_user_model", return_value=False):
+            resp = client.delete("/api/providers/ollama/models/missing-model")
+        assert resp.status_code == 404

--- a/apps/visualizer/backend/tests/test_system_vision_models.py
+++ b/apps/visualizer/backend/tests/test_system_vision_models.py
@@ -1,0 +1,113 @@
+import sqlite3
+from unittest.mock import MagicMock, patch
+
+import pytest
+from app import create_app
+
+
+@pytest.fixture()
+def client():
+    app = create_app()
+    app.config["TESTING"] = True
+    memory_db = sqlite3.connect(":memory:")
+    memory_db.row_factory = sqlite3.Row
+    memory_db.execute(
+        """
+        CREATE TABLE provider_models (
+            provider_id TEXT NOT NULL,
+            model_id TEXT NOT NULL,
+            model_name TEXT NOT NULL,
+            vision INTEGER DEFAULT 1,
+            PRIMARY KEY (provider_id, model_id)
+        )
+        """
+    )
+    memory_db.commit()
+    app.db = memory_db
+    with app.test_client() as test_client:
+        yield test_client
+    memory_db.close()
+
+
+class TestVisionModels:
+    def test_should_return_models_from_registry(self, client):
+        registry_instance = MagicMock()
+        registry_instance.defaults = {
+            "vision_comparison": {"provider": "ollama", "model": "gemma3:27b"},
+        }
+        registry_instance.list_providers.return_value = [
+            {"id": "ollama", "name": "Ollama", "available": True},
+        ]
+        registry_instance.list_models.return_value = [
+            {
+                "id": "gemma3:27b",
+                "name": "Gemma 3 27B",
+                "vision": True,
+                "source": "config",
+            },
+        ]
+
+        with patch(
+            "lightroom_tagger.core.provider_registry.ProviderRegistry",
+            return_value=registry_instance,
+        ):
+            resp = client.get("/api/vision-models")
+
+        assert resp.status_code == 200
+        payload = resp.get_json()
+        assert payload["fallback"] is False
+        models = payload["models"]
+        assert len(models) == 1
+        entry = models[0]
+        assert entry["name"] == "gemma3:27b"
+        assert entry["provider_id"] == "ollama"
+        assert "default" in entry
+
+    def test_should_mark_default_model(self, client):
+        registry_instance = MagicMock()
+        registry_instance.defaults = {
+            "vision_comparison": {"provider": "ollama", "model": "gemma3:27b"},
+        }
+        registry_instance.list_providers.return_value = [
+            {"id": "ollama", "name": "Ollama", "available": True},
+        ]
+        registry_instance.list_models.return_value = [
+            {
+                "id": "gemma3:27b",
+                "name": "Gemma",
+                "vision": True,
+                "source": "config",
+            },
+            {
+                "id": "other-vision",
+                "name": "Other",
+                "vision": True,
+                "source": "config",
+            },
+        ]
+
+        with patch(
+            "lightroom_tagger.core.provider_registry.ProviderRegistry",
+            return_value=registry_instance,
+        ):
+            resp = client.get("/api/vision-models")
+
+        assert resp.status_code == 200
+        models = resp.get_json()["models"]
+        default_flags = [model["default"] for model in models]
+        assert sum(1 for flag in default_flags if flag) == 1
+
+    def test_should_fallback_when_registry_fails(self, client):
+        def raise_registry(*args, **kwargs):
+            raise RuntimeError("registry unavailable")
+
+        with patch(
+            "lightroom_tagger.core.provider_registry.ProviderRegistry",
+            side_effect=raise_registry,
+        ):
+            resp = client.get("/api/vision-models")
+
+        assert resp.status_code == 200
+        payload = resp.get_json()
+        assert payload["fallback"] is True
+        assert payload["models"] == [{"name": "gemma3:27b", "default": True}]

--- a/apps/visualizer/frontend/src/components/instagram/SingleMatchSection.tsx
+++ b/apps/visualizer/frontend/src/components/instagram/SingleMatchSection.tsx
@@ -171,9 +171,9 @@ export function SingleMatchSection({ image }: SingleMatchSectionProps) {
         availableModels={availableModels}
         providerId={matchOptions.providerId}
         providerModel={matchOptions.providerModel}
-        onProviderChange={(pid, mid) => {
-          updateOption("providerId", pid);
-          updateOption("providerModel", mid);
+        onProviderChange={(providerId, modelId) => {
+          updateOption("providerId", providerId);
+          updateOption("providerModel", modelId);
         }}
         selectedModel={matchOptions.selectedModel}
         onModelChange={(model) => updateOption("selectedModel", model)}

--- a/apps/visualizer/frontend/src/components/instagram/SingleMatchSection.tsx
+++ b/apps/visualizer/frontend/src/components/instagram/SingleMatchSection.tsx
@@ -169,6 +169,12 @@ export function SingleMatchSection({ image }: SingleMatchSectionProps) {
         isOpen={advancedOpen}
         onToggle={() => setAdvancedOpen(!advancedOpen)}
         availableModels={availableModels}
+        providerId={matchOptions.providerId}
+        providerModel={matchOptions.providerModel}
+        onProviderChange={(pid, mid) => {
+          updateOption("providerId", pid);
+          updateOption("providerModel", mid);
+        }}
         selectedModel={matchOptions.selectedModel}
         onModelChange={(model) => updateOption("selectedModel", model)}
         threshold={matchOptions.threshold}

--- a/apps/visualizer/frontend/src/components/matching/AdvancedOptions.tsx
+++ b/apps/visualizer/frontend/src/components/matching/AdvancedOptions.tsx
@@ -1,9 +1,11 @@
 import { RangeSlider } from './RangeSlider';
 import { WeightSlider } from './WeightSlider';
+import { ProviderModelSelect } from '../ui/ProviderModelSelect';
 import {
   ADVANCED_OPTIONS_TITLE,
   ADVANCED_MODEL_LABEL,
   ADVANCED_MODEL_DESCRIPTION,
+  ADVANCED_PROVIDER_OVERRIDES_LEGACY_MODEL,
   ADVANCED_THRESHOLD_LABEL,
   ADVANCED_THRESHOLD_MIN,
   ADVANCED_THRESHOLD_MAX,
@@ -20,6 +22,9 @@ interface AdvancedOptionsProps {
   isOpen: boolean;
   onToggle: () => void;
   availableModels: { name: string; default: boolean }[];
+  providerId: string | null;
+  providerModel: string | null;
+  onProviderChange: (providerId: string | null, modelId: string | null) => void;
   selectedModel: string;
   onModelChange: (model: string) => void;
   threshold: number;
@@ -38,6 +43,9 @@ export function AdvancedOptions({
   isOpen,
   onToggle,
   availableModels,
+  providerId,
+  providerModel,
+  onProviderChange,
   selectedModel,
   onModelChange,
   threshold,
@@ -53,6 +61,7 @@ export function AdvancedOptions({
 }: AdvancedOptionsProps) {
   const totalWeight = phashWeight + descWeight + visionWeight;
   const weightsValid = Math.abs(totalWeight - 1.0) < 0.001;
+  const legacyModelDisabled = providerId !== null;
 
   return (
     <div className="border-t pt-4">
@@ -65,14 +74,24 @@ export function AdvancedOptions({
 
       {isOpen && (
         <div className="mt-4 space-y-4 bg-white p-4 rounded border">
-          <div>
+          <div className="space-y-2">
+            <ProviderModelSelect
+              providerId={providerId}
+              modelId={providerModel}
+              onChange={onProviderChange}
+            />
+            <p className="text-xs text-gray-500">{ADVANCED_PROVIDER_OVERRIDES_LEGACY_MODEL}</p>
+          </div>
+
+          <div className={legacyModelDisabled ? 'opacity-50' : ''}>
             <label className="block text-sm font-medium text-gray-700 mb-1">
               {ADVANCED_MODEL_LABEL}
             </label>
             <select
               value={selectedModel}
               onChange={(e) => onModelChange(e.target.value)}
-              className="w-full max-w-md px-3 py-2 border rounded text-sm"
+              disabled={legacyModelDisabled}
+              className="w-full max-w-md px-3 py-2 border rounded text-sm disabled:cursor-not-allowed"
             >
               {availableModels.length === 0 ? (
                 <option value="gemma3:27b">gemma3:27b (loading...)</option>

--- a/apps/visualizer/frontend/src/components/providers/AddModelForm.tsx
+++ b/apps/visualizer/frontend/src/components/providers/AddModelForm.tsx
@@ -31,8 +31,9 @@ export function AddModelForm({ onAdd }: AddModelFormProps) {
       setModelId('')
       setDisplayName('')
       setSupportsVision(true)
-    } catch {
-      setSubmitError(PROVIDER_ADD_MODEL_ERROR)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : PROVIDER_ADD_MODEL_ERROR
+      setSubmitError(message)
     } finally {
       setSubmitting(false)
     }

--- a/apps/visualizer/frontend/src/components/providers/AddModelForm.tsx
+++ b/apps/visualizer/frontend/src/components/providers/AddModelForm.tsx
@@ -1,0 +1,70 @@
+import { useState, type FormEvent } from 'react'
+import {
+  PROVIDER_ADD_MODEL_ID_LABEL,
+  PROVIDER_ADD_MODEL_NAME_LABEL,
+  PROVIDER_ADD_MODEL_VISION_LABEL,
+  PROVIDER_ADD_MODEL_SUBMIT,
+} from '../../constants/strings'
+
+interface AddModelFormProps {
+  onAdd: (model: { id: string; name: string; vision: boolean }) => void
+}
+
+export function AddModelForm({ onAdd }: AddModelFormProps) {
+  const [modelId, setModelId] = useState('')
+  const [displayName, setDisplayName] = useState('')
+  const [supportsVision, setSupportsVision] = useState(true)
+
+  function handleSubmit(event: FormEvent) {
+    event.preventDefault()
+    const trimmedId = modelId.trim()
+    const trimmedName = displayName.trim()
+    if (!trimmedId || !trimmedName) return
+    onAdd({ id: trimmedId, name: trimmedName, vision: supportsVision })
+    setModelId('')
+    setDisplayName('')
+    setSupportsVision(true)
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="mt-4 pt-4 border-t border-gray-100 space-y-3">
+      <div className="grid gap-2 sm:grid-cols-2">
+        <label className="block text-xs text-gray-600">
+          <span className="block mb-0.5">{PROVIDER_ADD_MODEL_ID_LABEL}</span>
+          <input
+            type="text"
+            value={modelId}
+            onChange={event => setModelId(event.target.value)}
+            className="w-full border border-gray-200 rounded px-2 py-1.5 text-sm font-mono"
+            autoComplete="off"
+          />
+        </label>
+        <label className="block text-xs text-gray-600">
+          <span className="block mb-0.5">{PROVIDER_ADD_MODEL_NAME_LABEL}</span>
+          <input
+            type="text"
+            value={displayName}
+            onChange={event => setDisplayName(event.target.value)}
+            className="w-full border border-gray-200 rounded px-2 py-1.5 text-sm"
+            autoComplete="off"
+          />
+        </label>
+      </div>
+      <label className="flex items-center gap-2 text-sm text-gray-700 cursor-pointer">
+        <input
+          type="checkbox"
+          checked={supportsVision}
+          onChange={event => setSupportsVision(event.target.checked)}
+          className="rounded border-gray-300"
+        />
+        {PROVIDER_ADD_MODEL_VISION_LABEL}
+      </label>
+      <button
+        type="submit"
+        className="px-3 py-1.5 text-sm font-medium rounded-md bg-indigo-600 text-white hover:bg-indigo-700"
+      >
+        {PROVIDER_ADD_MODEL_SUBMIT}
+      </button>
+    </form>
+  )
+}

--- a/apps/visualizer/frontend/src/components/providers/AddModelForm.tsx
+++ b/apps/visualizer/frontend/src/components/providers/AddModelForm.tsx
@@ -4,30 +4,47 @@ import {
   PROVIDER_ADD_MODEL_NAME_LABEL,
   PROVIDER_ADD_MODEL_VISION_LABEL,
   PROVIDER_ADD_MODEL_SUBMIT,
+  PROVIDER_ADD_MODEL_SUBMITTING,
+  PROVIDER_ADD_MODEL_ERROR,
 } from '../../constants/strings'
 
 interface AddModelFormProps {
-  onAdd: (model: { id: string; name: string; vision: boolean }) => void
+  onAdd: (model: { id: string; name: string; vision: boolean }) => Promise<void>
 }
 
 export function AddModelForm({ onAdd }: AddModelFormProps) {
   const [modelId, setModelId] = useState('')
   const [displayName, setDisplayName] = useState('')
   const [supportsVision, setSupportsVision] = useState(true)
+  const [submitting, setSubmitting] = useState(false)
+  const [submitError, setSubmitError] = useState<string | null>(null)
 
-  function handleSubmit(event: FormEvent) {
+  async function handleSubmit(event: FormEvent) {
     event.preventDefault()
     const trimmedId = modelId.trim()
     const trimmedName = displayName.trim()
-    if (!trimmedId || !trimmedName) return
-    onAdd({ id: trimmedId, name: trimmedName, vision: supportsVision })
-    setModelId('')
-    setDisplayName('')
-    setSupportsVision(true)
+    if (!trimmedId || !trimmedName || submitting) return
+    setSubmitting(true)
+    setSubmitError(null)
+    try {
+      await onAdd({ id: trimmedId, name: trimmedName, vision: supportsVision })
+      setModelId('')
+      setDisplayName('')
+      setSupportsVision(true)
+    } catch {
+      setSubmitError(PROVIDER_ADD_MODEL_ERROR)
+    } finally {
+      setSubmitting(false)
+    }
   }
 
   return (
-    <form onSubmit={handleSubmit} className="mt-4 pt-4 border-t border-gray-100 space-y-3">
+    <form onSubmit={event => handleSubmit(event).catch(console.error)} className="mt-4 pt-4 border-t border-gray-100 space-y-3">
+      {submitError ? (
+        <p className="text-sm text-red-600" role="alert">
+          {submitError}
+        </p>
+      ) : null}
       <div className="grid gap-2 sm:grid-cols-2">
         <label className="block text-xs text-gray-600">
           <span className="block mb-0.5">{PROVIDER_ADD_MODEL_ID_LABEL}</span>
@@ -37,6 +54,7 @@ export function AddModelForm({ onAdd }: AddModelFormProps) {
             onChange={event => setModelId(event.target.value)}
             className="w-full border border-gray-200 rounded px-2 py-1.5 text-sm font-mono"
             autoComplete="off"
+            disabled={submitting}
           />
         </label>
         <label className="block text-xs text-gray-600">
@@ -47,6 +65,7 @@ export function AddModelForm({ onAdd }: AddModelFormProps) {
             onChange={event => setDisplayName(event.target.value)}
             className="w-full border border-gray-200 rounded px-2 py-1.5 text-sm"
             autoComplete="off"
+            disabled={submitting}
           />
         </label>
       </div>
@@ -56,14 +75,16 @@ export function AddModelForm({ onAdd }: AddModelFormProps) {
           checked={supportsVision}
           onChange={event => setSupportsVision(event.target.checked)}
           className="rounded border-gray-300"
+          disabled={submitting}
         />
         {PROVIDER_ADD_MODEL_VISION_LABEL}
       </label>
       <button
         type="submit"
-        className="px-3 py-1.5 text-sm font-medium rounded-md bg-indigo-600 text-white hover:bg-indigo-700"
+        disabled={submitting}
+        className="px-3 py-1.5 text-sm font-medium rounded-md bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"
       >
-        {PROVIDER_ADD_MODEL_SUBMIT}
+        {submitting ? PROVIDER_ADD_MODEL_SUBMITTING : PROVIDER_ADD_MODEL_SUBMIT}
       </button>
     </form>
   )

--- a/apps/visualizer/frontend/src/components/providers/FallbackOrderPanel.tsx
+++ b/apps/visualizer/frontend/src/components/providers/FallbackOrderPanel.tsx
@@ -7,7 +7,7 @@ import {
   PROVIDER_MOVE_DOWN,
 } from '../../constants/strings'
 
-interface Props {
+interface FallbackOrderPanelProps {
   providers: Provider[]
   order: string[]
   onReorder: (order: string[]) => void
@@ -29,7 +29,7 @@ function reorderBySwappingNeighbors(
   return nextOrder
 }
 
-export function FallbackOrderPanel({ providers, order, onReorder }: Props) {
+export function FallbackOrderPanel({ providers, order, onReorder }: FallbackOrderPanelProps) {
   const providerMap = Object.fromEntries(providers.map(provider => [provider.id, provider]))
 
   return (

--- a/apps/visualizer/frontend/src/components/providers/FallbackOrderPanel.tsx
+++ b/apps/visualizer/frontend/src/components/providers/FallbackOrderPanel.tsx
@@ -3,14 +3,33 @@ import {
   PROVIDER_FALLBACK_HEADING,
   PROVIDER_FALLBACK_DESCRIPTION,
   PROVIDER_STATUS_SUFFIX_UNAVAILABLE,
+  PROVIDER_MOVE_UP,
+  PROVIDER_MOVE_DOWN,
 } from '../../constants/strings'
 
 interface Props {
   providers: Provider[]
   order: string[]
+  onReorder: (order: string[]) => void
 }
 
-export function FallbackOrderPanel({ providers, order }: Props) {
+function reorderBySwappingNeighbors(
+  currentOrder: string[],
+  index: number,
+  direction: 'up' | 'down',
+): string[] {
+  const neighborIndex = direction === 'up' ? index - 1 : index + 1
+  if (neighborIndex < 0 || neighborIndex >= currentOrder.length) {
+    return currentOrder
+  }
+  const nextOrder = [...currentOrder]
+  const temporary = nextOrder[index]
+  nextOrder[index] = nextOrder[neighborIndex]
+  nextOrder[neighborIndex] = temporary
+  return nextOrder
+}
+
+export function FallbackOrderPanel({ providers, order, onReorder }: Props) {
   const providerMap = Object.fromEntries(providers.map(provider => [provider.id, provider]))
 
   return (
@@ -20,15 +39,43 @@ export function FallbackOrderPanel({ providers, order }: Props) {
       <ol className="space-y-1.5">
         {order.map((providerId, index) => {
           const provider = providerMap[providerId]
+          const isFirst = index === 0
+          const isLast = index === order.length - 1
           return (
             <li key={providerId} className="flex items-center gap-2 text-sm">
               <span className="w-5 h-5 rounded-full bg-indigo-100 text-indigo-700 flex items-center justify-center text-xs font-bold">
                 {index + 1}
               </span>
-              <span className="font-medium text-gray-800">{provider?.name ?? providerId}</span>
+              <span className="font-medium text-gray-800 flex-1 min-w-0">
+                {provider?.name ?? providerId}
+              </span>
               {provider && !provider.available && (
                 <span className="text-xs text-gray-400">{PROVIDER_STATUS_SUFFIX_UNAVAILABLE}</span>
               )}
+              <span className="flex items-center gap-0.5 shrink-0">
+                <button
+                  type="button"
+                  disabled={isFirst}
+                  aria-label={PROVIDER_MOVE_UP}
+                  onClick={() => {
+                    onReorder(reorderBySwappingNeighbors(order, index, 'up'))
+                  }}
+                  className="px-1.5 py-0.5 rounded border border-gray-200 text-gray-600 hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed"
+                >
+                  ↑
+                </button>
+                <button
+                  type="button"
+                  disabled={isLast}
+                  aria-label={PROVIDER_MOVE_DOWN}
+                  onClick={() => {
+                    onReorder(reorderBySwappingNeighbors(order, index, 'down'))
+                  }}
+                  className="px-1.5 py-0.5 rounded border border-gray-200 text-gray-600 hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed"
+                >
+                  ↓
+                </button>
+              </span>
             </li>
           )
         })}

--- a/apps/visualizer/frontend/src/components/providers/ModelList.tsx
+++ b/apps/visualizer/frontend/src/components/providers/ModelList.tsx
@@ -1,0 +1,66 @@
+import type { ProviderModel } from '../../services/api'
+import {
+  PROVIDER_COL_MODEL,
+  PROVIDER_COL_VISION,
+  PROVIDER_COL_SOURCE,
+  PROVIDER_SOURCE_CONFIG,
+  PROVIDER_SOURCE_DISCOVERED,
+  PROVIDER_SOURCE_USER,
+  PROVIDER_REMOVE_MODEL,
+  PROVIDER_COL_ACTIONS,
+} from '../../constants/strings'
+
+const SOURCE_LABELS: Record<string, string> = {
+  config: PROVIDER_SOURCE_CONFIG,
+  discovered: PROVIDER_SOURCE_DISCOVERED,
+  user: PROVIDER_SOURCE_USER,
+}
+
+interface ModelListProps {
+  models: ProviderModel[]
+  onRemove: (modelId: string) => void
+}
+
+export function ModelList({ models, onRemove }: ModelListProps) {
+  return (
+    <table className="w-full text-sm">
+      <thead>
+        <tr className="text-left text-gray-500 text-xs uppercase tracking-wider">
+          <th className="pb-1">{PROVIDER_COL_MODEL}</th>
+          <th className="pb-1">{PROVIDER_COL_VISION}</th>
+          <th className="pb-1">{PROVIDER_COL_SOURCE}</th>
+          <th className="pb-1 w-10 text-right font-normal">{PROVIDER_COL_ACTIONS}</th>
+        </tr>
+      </thead>
+      <tbody className="divide-y divide-gray-50">
+        {models.map(model => (
+          <tr key={model.id}>
+            <td className="py-1.5 font-mono text-xs text-gray-800">{model.name}</td>
+            <td className="py-1.5">
+              {model.vision ? (
+                <span className="text-green-600">✓</span>
+              ) : (
+                <span className="text-gray-300">—</span>
+              )}
+            </td>
+            <td className="py-1.5 text-xs text-gray-500">
+              {SOURCE_LABELS[model.source] ?? model.source}
+            </td>
+            <td className="py-1.5 text-right">
+              {model.source === 'user' ? (
+                <button
+                  type="button"
+                  onClick={() => onRemove(model.id)}
+                  aria-label={PROVIDER_REMOVE_MODEL}
+                  className="text-gray-400 hover:text-red-600 text-base leading-none px-1"
+                >
+                  ×
+                </button>
+              ) : null}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}

--- a/apps/visualizer/frontend/src/components/providers/ProviderCard.tsx
+++ b/apps/visualizer/frontend/src/components/providers/ProviderCard.tsx
@@ -13,7 +13,7 @@ interface ProviderCardProps {
   models: ProviderModel[]
   expanded: boolean
   onToggle: () => void
-  onAddModel: (model: { id: string; name: string; vision: boolean }) => void
+  onAddModel: (model: { id: string; name: string; vision: boolean }) => Promise<void>
   onRemoveModel: (modelId: string) => void
 }
 

--- a/apps/visualizer/frontend/src/components/providers/ProviderCard.tsx
+++ b/apps/visualizer/frontend/src/components/providers/ProviderCard.tsx
@@ -4,28 +4,27 @@ import {
   PROVIDER_STATUS_UNAVAILABLE,
   PROVIDER_MODELS_HEADING,
   PROVIDER_NO_MODELS,
-  PROVIDER_COL_MODEL,
-  PROVIDER_COL_VISION,
-  PROVIDER_COL_SOURCE,
-  PROVIDER_SOURCE_CONFIG,
-  PROVIDER_SOURCE_DISCOVERED,
-  PROVIDER_SOURCE_USER,
 } from '../../constants/strings'
+import { ModelList } from './ModelList'
+import { AddModelForm } from './AddModelForm'
 
-const SOURCE_LABELS: Record<string, string> = {
-  config: PROVIDER_SOURCE_CONFIG,
-  discovered: PROVIDER_SOURCE_DISCOVERED,
-  user: PROVIDER_SOURCE_USER,
-}
-
-interface Props {
+interface ProviderCardProps {
   provider: Provider
   models: ProviderModel[]
   expanded: boolean
   onToggle: () => void
+  onAddModel: (model: { id: string; name: string; vision: boolean }) => void
+  onRemoveModel: (modelId: string) => void
 }
 
-export function ProviderCard({ provider, models, expanded, onToggle }: Props) {
+export function ProviderCard({
+  provider,
+  models,
+  expanded,
+  onToggle,
+  onAddModel,
+  onRemoveModel,
+}: ProviderCardProps) {
   return (
     <div className="rounded-lg border border-gray-200 bg-white shadow-sm">
       <button
@@ -54,33 +53,9 @@ export function ProviderCard({ provider, models, expanded, onToggle }: Props) {
           {models.length === 0 ? (
             <p className="text-sm text-gray-400">{PROVIDER_NO_MODELS}</p>
           ) : (
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="text-left text-gray-500 text-xs uppercase tracking-wider">
-                  <th className="pb-1">{PROVIDER_COL_MODEL}</th>
-                  <th className="pb-1">{PROVIDER_COL_VISION}</th>
-                  <th className="pb-1">{PROVIDER_COL_SOURCE}</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-gray-50">
-                {models.map(model => (
-                  <tr key={model.id}>
-                    <td className="py-1.5 font-mono text-xs text-gray-800">{model.name}</td>
-                    <td className="py-1.5">
-                      {model.vision ? (
-                        <span className="text-green-600">✓</span>
-                      ) : (
-                        <span className="text-gray-300">—</span>
-                      )}
-                    </td>
-                    <td className="py-1.5 text-xs text-gray-500">
-                      {SOURCE_LABELS[model.source] ?? model.source}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+            <ModelList models={models} onRemove={onRemoveModel} />
           )}
+          <AddModelForm onAdd={onAddModel} />
         </div>
       )}
     </div>

--- a/apps/visualizer/frontend/src/components/providers/index.ts
+++ b/apps/visualizer/frontend/src/components/providers/index.ts
@@ -1,2 +1,4 @@
 export { ProviderCard } from './ProviderCard'
 export { FallbackOrderPanel } from './FallbackOrderPanel'
+export { ModelList } from './ModelList'
+export { AddModelForm } from './AddModelForm'

--- a/apps/visualizer/frontend/src/components/ui/ProviderModelSelect.tsx
+++ b/apps/visualizer/frontend/src/components/ui/ProviderModelSelect.tsx
@@ -9,14 +9,14 @@ import {
   MSG_LOADING,
 } from '../../constants/strings'
 
-interface Props {
+interface ProviderModelSelectProps {
   providerId: string | null
   modelId: string | null
   onChange: (providerId: string | null, modelId: string | null) => void
   className?: string
 }
 
-export function ProviderModelSelect({ providerId, modelId, onChange, className = '' }: Props) {
+export function ProviderModelSelect({ providerId, modelId, onChange, className = '' }: ProviderModelSelectProps) {
   const { providers } = useProviders()
   const { models, loading: modelsLoading } = useProviderModels(providerId)
 

--- a/apps/visualizer/frontend/src/constants/strings.ts
+++ b/apps/visualizer/frontend/src/constants/strings.ts
@@ -149,6 +149,8 @@ export const ADVANCED_DATE_YEAR_2026 = '2026 only'
 
 export const ADVANCED_MODEL_LABEL = 'Vision Model'
 export const ADVANCED_MODEL_DESCRIPTION = 'Model used for vision comparison'
+export const ADVANCED_PROVIDER_OVERRIDES_LEGACY_MODEL =
+  'Provider-specific model selection overrides the legacy Ollama model below when set.'
 
 export const ADVANCED_THRESHOLD_LABEL = 'Match Threshold'
 export const ADVANCED_THRESHOLD_MIN = '0.50 (lenient)'
@@ -304,10 +306,18 @@ export const PROVIDER_NO_MODELS = 'No models available'
 export const PROVIDER_COL_MODEL = 'Model'
 export const PROVIDER_COL_VISION = 'Vision'
 export const PROVIDER_COL_SOURCE = 'Source'
+export const PROVIDER_COL_ACTIONS = 'Actions'
 export const PROVIDER_SELECT_LABEL = 'Provider'
 export const PROVIDER_MODEL_SELECT_LABEL = 'Model'
 export const PROVIDER_AUTO_DEFAULT = 'Auto (default)'
 export const PROVIDER_MODEL_AUTO_FIRST = 'Auto (first available)'
+export const PROVIDER_MOVE_UP = 'Move provider up in fallback order'
+export const PROVIDER_MOVE_DOWN = 'Move provider down in fallback order'
+export const PROVIDER_REMOVE_MODEL = 'Remove user-added model'
+export const PROVIDER_ADD_MODEL_ID_LABEL = 'Model ID'
+export const PROVIDER_ADD_MODEL_NAME_LABEL = 'Display name'
+export const PROVIDER_ADD_MODEL_VISION_LABEL = 'Supports vision'
+export const PROVIDER_ADD_MODEL_SUBMIT = 'Add model'
 
 // Generic Buttons
 export const BTN_DISMISS = 'Dismiss'

--- a/apps/visualizer/frontend/src/constants/strings.ts
+++ b/apps/visualizer/frontend/src/constants/strings.ts
@@ -318,6 +318,8 @@ export const PROVIDER_ADD_MODEL_ID_LABEL = 'Model ID'
 export const PROVIDER_ADD_MODEL_NAME_LABEL = 'Display name'
 export const PROVIDER_ADD_MODEL_VISION_LABEL = 'Supports vision'
 export const PROVIDER_ADD_MODEL_SUBMIT = 'Add model'
+export const PROVIDER_ADD_MODEL_SUBMITTING = 'Adding…'
+export const PROVIDER_ADD_MODEL_ERROR = 'Could not add model. Please try again.'
 
 // Generic Buttons
 export const BTN_DISMISS = 'Dismiss'

--- a/apps/visualizer/frontend/src/hooks/useProviders.ts
+++ b/apps/visualizer/frontend/src/hooks/useProviders.ts
@@ -26,7 +26,12 @@ export function useProviders() {
 
   useEffect(() => { refresh() }, [refresh])
 
-  return { providers, fallbackOrder, loading, error, refresh }
+  const updateFallbackOrder = useCallback(async (order: string[]) => {
+    await ProvidersAPI.updateFallbackOrder(order)
+    await refresh()
+  }, [refresh])
+
+  return { providers, fallbackOrder, loading, error, refresh, updateFallbackOrder }
 }
 
 export function useProviderModels(providerId: string | null) {

--- a/apps/visualizer/frontend/src/hooks/useProviders.ts
+++ b/apps/visualizer/frontend/src/hooks/useProviders.ts
@@ -37,18 +37,24 @@ export function useProviders() {
 export function useProviderModels(providerId: string | null) {
   const [models, setModels] = useState<ProviderModel[]>([])
   const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
     if (!providerId) {
       setModels([])
+      setError(null)
       return
     }
     setLoading(true)
+    setError(null)
     ProvidersAPI.listModels(providerId)
       .then(setModels)
-      .catch(() => setModels([]))
+      .catch((err) => {
+        setModels([])
+        setError(err instanceof Error ? err.message : 'Failed to load models')
+      })
       .finally(() => setLoading(false))
   }, [providerId])
 
-  return { models, loading }
+  return { models, loading, error }
 }

--- a/apps/visualizer/frontend/src/hooks/useSingleMatch.ts
+++ b/apps/visualizer/frontend/src/hooks/useSingleMatch.ts
@@ -67,7 +67,7 @@ export function useSingleMatch(imageKey: string) {
   );
 
   const startSingleMatch = useCallback(
-    async (key: string, opts?: { forceReprocess?: boolean }) => {
+    async (key: string, options?: { forceReprocess?: boolean }) => {
       setMatchState("running");
       setMatchResult(null);
       setMatchError(null);
@@ -82,7 +82,13 @@ export function useSingleMatch(imageKey: string) {
             vision: matchOptions.visionWeight,
           },
         };
-        if (opts?.forceReprocess) metadata.force_reprocess = true;
+        if (matchOptions.providerId) {
+          metadata.provider_id = matchOptions.providerId;
+          if (matchOptions.providerModel) {
+            metadata.provider_model = matchOptions.providerModel;
+          }
+        }
+        if (options?.forceReprocess) metadata.force_reprocess = true;
         const job = await JobsAPI.create("vision_match", metadata);
         setMatchJob(job);
         pollJob(job.id);

--- a/apps/visualizer/frontend/src/hooks/useSingleMatch.ts
+++ b/apps/visualizer/frontend/src/hooks/useSingleMatch.ts
@@ -74,13 +74,15 @@ export function useSingleMatch(imageKey: string) {
       try {
         const metadata: Record<string, unknown> = {
           media_key: key,
-          vision_model: matchOptions.selectedModel,
           threshold: matchOptions.threshold,
           weights: {
             phash: matchOptions.phashWeight,
             description: matchOptions.descWeight,
             vision: matchOptions.visionWeight,
           },
+          ...(matchOptions.providerId
+            ? {}
+            : { vision_model: matchOptions.selectedModel || undefined }),
         };
         if (matchOptions.providerId) {
           metadata.provider_id = matchOptions.providerId;

--- a/apps/visualizer/frontend/src/pages/DescriptionsPage.tsx
+++ b/apps/visualizer/frontend/src/pages/DescriptionsPage.tsx
@@ -2,6 +2,7 @@ import { Suspense, useEffect, useMemo, useState } from 'react';
 import type { DescriptionItem, ImageDescription, Job } from '../services/api';
 import { DescriptionsAPI, JobsAPI } from '../services/api';
 import { Alert } from '../components/ui/Alert';
+import { ProviderModelSelect } from '../components/ui/ProviderModelSelect';
 import { BatchActionPanel } from '../components/descriptions/BatchActionPanel';
 import { DescriptionDetailModal } from '../components/descriptions/DescriptionDetailModal';
 import { DescriptionGrid } from '../components/descriptions/DescriptionGrid';
@@ -38,7 +39,7 @@ const BATCH_LABELS: Record<TabValue, string> = {
 };
 
 export function DescriptionsPage() {
-  const { availableModels } = useMatchOptions();
+  const { options, updateOption, availableModels } = useMatchOptions();
 
   const [page, setPage] = useState(1);
   const [tab, setTab] = useState<TabValue>('all');
@@ -86,6 +87,8 @@ export function DescriptionsPage() {
         date_filter: dateFilter,
         force,
         vision_model: selectedModel || undefined,
+        ...(options.providerId ? { provider_id: options.providerId } : {}),
+        ...(options.providerModel ? { provider_model: options.providerModel } : {}),
       });
       setBatchJob(job);
     } catch (err) {
@@ -105,6 +108,8 @@ export function DescriptionsPage() {
         item.image_type,
         force,
         selectedModel || undefined,
+        options.providerId ?? undefined,
+        options.providerModel ?? undefined,
       );
       if (res.description) {
         setRefreshKey(prev => prev + 1);
@@ -164,22 +169,32 @@ export function DescriptionsPage() {
         </Suspense>
       </div>
 
-      <BatchActionPanel
-        availableModels={availableModels}
-        selectedModel={selectedModel}
-        onModelChange={setSelectedModel}
-        dateFilter={dateFilter}
-        onDateFilterChange={setDateFilter}
-        force={force}
-        onForceChange={setForce}
-        batchRunning={batchRunning}
-        batchLabel={BATCH_LABELS[tab]}
-        onBatchDescribe={handleBatchDescribe}
-        batchJob={batchJob}
-        onDismissJob={() => setBatchJob(null)}
-        batchError={batchError}
-        onDismissError={() => setBatchError(null)}
-      />
+      <div className="space-y-3">
+        <ProviderModelSelect
+          providerId={options.providerId}
+          modelId={options.providerModel}
+          onChange={(nextProviderId, nextModelId) => {
+            updateOption('providerId', nextProviderId);
+            updateOption('providerModel', nextModelId);
+          }}
+        />
+        <BatchActionPanel
+          availableModels={availableModels}
+          selectedModel={selectedModel}
+          onModelChange={setSelectedModel}
+          dateFilter={dateFilter}
+          onDateFilterChange={setDateFilter}
+          force={force}
+          onForceChange={setForce}
+          batchRunning={batchRunning}
+          batchLabel={BATCH_LABELS[tab]}
+          onBatchDescribe={handleBatchDescribe}
+          batchJob={batchJob}
+          onDismissJob={() => setBatchJob(null)}
+          batchError={batchError}
+          onDismissError={() => setBatchError(null)}
+        />
+      </div>
 
       {generateError && (
         <Alert tone="danger" message={generateError} onDismiss={() => setGenerateError(null)} />

--- a/apps/visualizer/frontend/src/pages/DescriptionsPage.tsx
+++ b/apps/visualizer/frontend/src/pages/DescriptionsPage.tsx
@@ -86,7 +86,9 @@ export function DescriptionsPage() {
         image_type: tab === 'all' ? 'both' : tab,
         date_filter: dateFilter,
         force,
-        vision_model: selectedModel || undefined,
+        ...(options.providerId || options.providerModel
+          ? {}
+          : { vision_model: selectedModel || undefined }),
         ...(options.providerId ? { provider_id: options.providerId } : {}),
         ...(options.providerModel ? { provider_model: options.providerModel } : {}),
       });

--- a/apps/visualizer/frontend/src/pages/DescriptionsPage.tsx
+++ b/apps/visualizer/frontend/src/pages/DescriptionsPage.tsx
@@ -86,7 +86,7 @@ export function DescriptionsPage() {
         image_type: tab === 'all' ? 'both' : tab,
         date_filter: dateFilter,
         force,
-        ...(options.providerId || options.providerModel
+        ...(options.providerId
           ? {}
           : { vision_model: selectedModel || undefined }),
         ...(options.providerId ? { provider_id: options.providerId } : {}),

--- a/apps/visualizer/frontend/src/pages/MatchingPage.tsx
+++ b/apps/visualizer/frontend/src/pages/MatchingPage.tsx
@@ -170,13 +170,15 @@ export function MatchingPage() {
     setIsStarting(true);
 
     const metadata: Record<string, unknown> = {
-      vision_model: options.selectedModel,
       threshold: options.threshold,
       weights: {
         phash: options.phashWeight,
         description: options.descWeight,
         vision: options.visionWeight,
       },
+      ...(options.providerId
+        ? {}
+        : { vision_model: options.selectedModel || undefined }),
     };
 
     if (options.providerId) {

--- a/apps/visualizer/frontend/src/pages/MatchingPage.tsx
+++ b/apps/visualizer/frontend/src/pages/MatchingPage.tsx
@@ -179,6 +179,11 @@ export function MatchingPage() {
       },
     };
 
+    if (options.providerId) {
+      metadata.provider_id = options.providerId;
+      if (options.providerModel) metadata.provider_model = options.providerModel;
+    }
+
     if (forceDescriptions) metadata.force_descriptions = true;
     if (forceReprocess) metadata.force_reprocess = true;
 
@@ -347,6 +352,10 @@ export function MatchingPage() {
             onToggle={() => setShowAdvanced(!showAdvanced)}
             availableModels={availableModels}
             {...options}
+            onProviderChange={(providerId, modelId) => {
+              updateOption('providerId', providerId);
+              updateOption('providerModel', modelId);
+            }}
             onModelChange={(v) => updateOption('selectedModel', v)}
             onThresholdChange={(v) => updateOption('threshold', v)}
             onPhashWeightChange={(v) => updateOption('phashWeight', v)}
@@ -390,18 +399,18 @@ export function MatchingPage() {
             setSelectedMatch(null);
             setSelectedGroup(null);
           }}
-          onValidationChange={(m, validated) => {
-            handleValidationChange(m, validated);
+          onValidationChange={(match, validated) => {
+            handleValidationChange(match, validated);
             setSelectedMatch((prev) =>
               prev ? { ...prev, validated_at: validated ? new Date().toISOString() : undefined } : null
             );
           }}
-          onRejected={(m) => {
-            handleRejected(m);
+          onRejected={(match) => {
+            handleRejected(match);
             setSelectedMatch(null);
             setSelectedGroup(null);
           }}
-          onCandidateChange={(c) => setSelectedMatch(c)}
+          onCandidateChange={(candidate) => setSelectedMatch(candidate)}
         />
       )}
     </div>

--- a/apps/visualizer/frontend/src/pages/ProvidersPage.tsx
+++ b/apps/visualizer/frontend/src/pages/ProvidersPage.tsx
@@ -51,9 +51,7 @@ export function ProvidersPage() {
             models={modelCache[provider.id] ?? []}
             expanded={expandedId === provider.id}
             onToggle={() => setExpandedId(previous => (previous === provider.id ? null : provider.id))}
-            onAddModel={model => {
-              handleAddModel(provider.id, model).catch(console.error)
-            }}
+            onAddModel={model => handleAddModel(provider.id, model)}
             onRemoveModel={modelId => {
               handleRemoveModel(provider.id, modelId).catch(console.error)
             }}

--- a/apps/visualizer/frontend/src/pages/ProvidersPage.tsx
+++ b/apps/visualizer/frontend/src/pages/ProvidersPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { ProvidersAPI, type ProviderModel } from '../services/api'
 import { useProviders } from '../hooks/useProviders'
 import { ProviderCard, FallbackOrderPanel } from '../components/providers'
@@ -6,16 +6,35 @@ import { PageLoading, PageError } from '../components/ui/page-states'
 import { PROVIDER_TITLE } from '../constants/strings'
 
 export function ProvidersPage() {
-  const { providers, fallbackOrder, loading, error } = useProviders()
+  const { providers, fallbackOrder, loading, error, updateFallbackOrder } = useProviders()
   const [expandedId, setExpandedId] = useState<string | null>(null)
   const [modelCache, setModelCache] = useState<Record<string, ProviderModel[]>>({})
 
+  const refreshModelsForProvider = useCallback(async (providerId: string) => {
+    const models = await ProvidersAPI.listModels(providerId)
+    setModelCache(previous => ({ ...previous, [providerId]: models }))
+  }, [])
+
   useEffect(() => {
     if (!expandedId || modelCache[expandedId]) return
-    ProvidersAPI.listModels(expandedId).then(models => {
-      setModelCache(prev => ({ ...prev, [expandedId]: models }))
-    })
-  }, [expandedId, modelCache])
+    refreshModelsForProvider(expandedId).catch(console.error)
+  }, [expandedId, modelCache, refreshModelsForProvider])
+
+  const handleAddModel = useCallback(
+    async (providerId: string, model: { id: string; name: string; vision: boolean }) => {
+      await ProvidersAPI.addModel(providerId, model)
+      await refreshModelsForProvider(providerId)
+    },
+    [refreshModelsForProvider],
+  )
+
+  const handleRemoveModel = useCallback(
+    async (providerId: string, modelId: string) => {
+      await ProvidersAPI.removeModel(providerId, modelId)
+      await refreshModelsForProvider(providerId)
+    },
+    [refreshModelsForProvider],
+  )
 
   if (loading) return <PageLoading />
   if (error) return <PageError message={error} />
@@ -31,12 +50,24 @@ export function ProvidersPage() {
             provider={provider}
             models={modelCache[provider.id] ?? []}
             expanded={expandedId === provider.id}
-            onToggle={() => setExpandedId(prev => (prev === provider.id ? null : provider.id))}
+            onToggle={() => setExpandedId(previous => (previous === provider.id ? null : provider.id))}
+            onAddModel={model => {
+              handleAddModel(provider.id, model).catch(console.error)
+            }}
+            onRemoveModel={modelId => {
+              handleRemoveModel(provider.id, modelId).catch(console.error)
+            }}
           />
         ))}
       </div>
 
-      <FallbackOrderPanel providers={providers} order={fallbackOrder} />
+      <FallbackOrderPanel
+        providers={providers}
+        order={fallbackOrder}
+        onReorder={order => {
+          updateFallbackOrder(order).catch(console.error)
+        }}
+      />
     </div>
   )
 }

--- a/apps/visualizer/frontend/src/services/api.ts
+++ b/apps/visualizer/frontend/src/services/api.ts
@@ -50,7 +50,10 @@ export const SystemAPI = {
     request<Stats>('/stats'),
 
   visionModels: () =>
-    request<{ models: { name: string; default: boolean }[]; fallback: boolean }>('/vision-models'),
+    request<{
+      models: { name: string; default: boolean; provider_id?: string }[]
+      fallback: boolean
+    }>('/vision-models'),
 
   cacheStatus: () =>
     request<CacheStatus>('/cache/status'),
@@ -343,7 +346,7 @@ export const ProvidersAPI = {
       method: 'PUT',
       body: JSON.stringify({ order }),
     }),
-  updateDefaults: (defaults: ProviderDefaults) =>
+  updateDefaults: (defaults: Partial<ProviderDefaults>) =>
     request<ProviderDefaults>('/providers/defaults', {
       method: 'PUT',
       body: JSON.stringify(defaults),

--- a/apps/visualizer/frontend/src/services/api.ts
+++ b/apps/visualizer/frontend/src/services/api.ts
@@ -338,4 +338,27 @@ export const ProvidersAPI = {
     request<{ order: string[] }>('/providers/fallback-order'),
   getDefaults: () =>
     request<ProviderDefaults>('/providers/defaults'),
+  updateFallbackOrder: (order: string[]) =>
+    request<{ order: string[] }>('/providers/fallback-order', {
+      method: 'PUT',
+      body: JSON.stringify({ order }),
+    }),
+  updateDefaults: (defaults: Record<string, unknown>) =>
+    request<Record<string, unknown>>('/providers/defaults', {
+      method: 'PUT',
+      body: JSON.stringify(defaults),
+    }),
+  addModel: (
+    providerId: string,
+    model: { id: string; name: string; vision: boolean },
+  ) =>
+    request<ProviderModel>(`/providers/${providerId}/models`, {
+      method: 'POST',
+      body: JSON.stringify(model),
+    }),
+  removeModel: (providerId: string, modelId: string) =>
+    request<{ deleted: boolean }>(
+      `/providers/${providerId}/models/${encodeURIComponent(modelId)}`,
+      { method: 'DELETE' },
+    ),
 }

--- a/apps/visualizer/frontend/src/services/api.ts
+++ b/apps/visualizer/frontend/src/services/api.ts
@@ -343,8 +343,8 @@ export const ProvidersAPI = {
       method: 'PUT',
       body: JSON.stringify({ order }),
     }),
-  updateDefaults: (defaults: Record<string, unknown>) =>
-    request<Record<string, unknown>>('/providers/defaults', {
+  updateDefaults: (defaults: ProviderDefaults) =>
+    request<ProviderDefaults>('/providers/defaults', {
       method: 'PUT',
       body: JSON.stringify(defaults),
     }),

--- a/apps/visualizer/frontend/src/stores/matchOptionsContext.tsx
+++ b/apps/visualizer/frontend/src/stores/matchOptionsContext.tsx
@@ -44,30 +44,27 @@ export function MatchOptionsProvider({ children }: { children: ReactNode }) {
   const [availableModels, setAvailableModels] = useState<VisionModelOption[]>([]);
 
   useEffect(() => {
-    SystemAPI.visionModels()
-      .then((data) => {
-        setAvailableModels(data.models);
-        const legacyModels = data.models.filter(
+    Promise.all([SystemAPI.visionModels(), ProvidersAPI.getDefaults()])
+      .then(([modelsData, defaults]) => {
+        setAvailableModels(modelsData.models);
+
+        const legacyModels = modelsData.models.filter(
           (model) => !model.provider_id || model.provider_id === 'ollama',
         );
         const defaultLegacyModel =
           legacyModels.find((model) => model.default) ?? legacyModels[0];
-        if (defaultLegacyModel) {
-          setOptions((prev) => ({ ...prev, selectedModel: defaultLegacyModel.name }));
-        }
-      })
-      .catch(console.error);
-  }, []);
 
-  useEffect(() => {
-    ProvidersAPI.getDefaults()
-      .then((defaults) => {
         const visionComparison = defaults.vision_comparison;
-        if (!visionComparison?.provider) return;
+
         setOptions((prev) => ({
           ...prev,
-          providerId: visionComparison.provider,
-          providerModel: visionComparison.model ?? null,
+          ...(defaultLegacyModel ? { selectedModel: defaultLegacyModel.name } : {}),
+          ...(visionComparison?.provider
+            ? {
+                providerId: visionComparison.provider,
+                providerModel: visionComparison.model ?? null,
+              }
+            : {}),
         }));
       })
       .catch(console.error);

--- a/apps/visualizer/frontend/src/stores/matchOptionsContext.tsx
+++ b/apps/visualizer/frontend/src/stores/matchOptionsContext.tsx
@@ -1,10 +1,12 @@
 import { createContext, useContext, useEffect, useState, useCallback, useMemo } from 'react';
 import type { ReactNode } from 'react';
-import { SystemAPI } from '../services/api';
+import { ProvidersAPI, SystemAPI } from '../services/api';
 import { ADVANCED_WEIGHTS_MUST_SUM } from '../constants/strings';
 
 interface MatchOptions {
   selectedModel: string;
+  providerId: string | null;
+  providerModel: string | null;
   threshold: number;
   phashWeight: number;
   descWeight: number;
@@ -13,6 +15,8 @@ interface MatchOptions {
 
 const DEFAULT_OPTIONS: MatchOptions = {
   selectedModel: '',
+  providerId: null,
+  providerModel: null,
   threshold: 0.7,
   phashWeight: 0,
   descWeight: 0,
@@ -43,12 +47,31 @@ export function MatchOptionsProvider({ children }: { children: ReactNode }) {
       .catch(console.error);
   }, []);
 
+  useEffect(() => {
+    ProvidersAPI.getDefaults()
+      .then((defaults) => {
+        const visionComparison = defaults.vision_comparison;
+        if (!visionComparison?.provider) return;
+        setOptions((prev) => ({
+          ...prev,
+          providerId: visionComparison.provider,
+          providerModel: visionComparison.model ?? null,
+        }));
+      })
+      .catch(console.error);
+  }, []);
+
   const updateOption = useCallback(<K extends keyof MatchOptions>(key: K, value: MatchOptions[K]) => {
     setOptions((prev) => ({ ...prev, [key]: value }));
   }, []);
 
   const resetOptions = useCallback(() => {
-    setOptions((prev) => ({ ...DEFAULT_OPTIONS, selectedModel: prev.selectedModel }));
+    setOptions((prev) => ({
+      ...DEFAULT_OPTIONS,
+      selectedModel: prev.selectedModel,
+      providerId: prev.providerId,
+      providerModel: prev.providerModel,
+    }));
   }, []);
 
   const weightsError = useMemo(() => {
@@ -72,7 +95,7 @@ export function MatchOptionsProvider({ children }: { children: ReactNode }) {
 }
 
 export function useMatchOptions() {
-  const ctx = useContext(MatchOptionsContext);
-  if (!ctx) throw new Error('useMatchOptions must be used within MatchOptionsProvider');
-  return ctx;
+  const context = useContext(MatchOptionsContext);
+  if (!context) throw new Error('useMatchOptions must be used within MatchOptionsProvider');
+  return context;
 }

--- a/apps/visualizer/frontend/src/stores/matchOptionsContext.tsx
+++ b/apps/visualizer/frontend/src/stores/matchOptionsContext.tsx
@@ -47,8 +47,14 @@ export function MatchOptionsProvider({ children }: { children: ReactNode }) {
     SystemAPI.visionModels()
       .then((data) => {
         setAvailableModels(data.models);
-        const defaultModel = data.models.find((model) => model.default) ?? data.models[0];
-        if (defaultModel) setOptions((prev) => ({ ...prev, selectedModel: defaultModel.name }));
+        const legacyModels = data.models.filter(
+          (model) => !model.provider_id || model.provider_id === 'ollama',
+        );
+        const defaultLegacyModel =
+          legacyModels.find((model) => model.default) ?? legacyModels[0];
+        if (defaultLegacyModel) {
+          setOptions((prev) => ({ ...prev, selectedModel: defaultLegacyModel.name }));
+        }
       })
       .catch(console.error);
   }, []);

--- a/apps/visualizer/frontend/src/stores/matchOptionsContext.tsx
+++ b/apps/visualizer/frontend/src/stores/matchOptionsContext.tsx
@@ -23,11 +23,17 @@ const DEFAULT_OPTIONS: MatchOptions = {
   visionWeight: 1,
 };
 
+type VisionModelOption = {
+  name: string;
+  default: boolean;
+  provider_id?: string;
+};
+
 interface MatchOptionsContextValue {
   options: MatchOptions;
   updateOption: <K extends keyof MatchOptions>(key: K, value: MatchOptions[K]) => void;
   resetOptions: () => void;
-  availableModels: { name: string; default: boolean }[];
+  availableModels: VisionModelOption[];
   weightsError: string | null;
 }
 
@@ -35,13 +41,13 @@ const MatchOptionsContext = createContext<MatchOptionsContextValue | null>(null)
 
 export function MatchOptionsProvider({ children }: { children: ReactNode }) {
   const [options, setOptions] = useState<MatchOptions>({ ...DEFAULT_OPTIONS });
-  const [availableModels, setAvailableModels] = useState<{ name: string; default: boolean }[]>([]);
+  const [availableModels, setAvailableModels] = useState<VisionModelOption[]>([]);
 
   useEffect(() => {
     SystemAPI.visionModels()
       .then((data) => {
         setAvailableModels(data.models);
-        const defaultModel = data.models.find((m) => m.default) ?? data.models[0];
+        const defaultModel = data.models.find((model) => model.default) ?? data.models[0];
         if (defaultModel) setOptions((prev) => ({ ...prev, selectedModel: defaultModel.name }));
       })
       .catch(console.error);

--- a/lightroom_tagger/core/provider_registry.py
+++ b/lightroom_tagger/core/provider_registry.py
@@ -19,7 +19,7 @@ class ProviderRegistry:
 
     def __init__(self, config_path: Path = _CONFIG_PATH):
         self._config_path = config_path
-        with open(config_path) as f:
+        with open(self._config_path, encoding="utf-8") as f:
             self._config: dict[str, Any] = json.load(f)
         self._providers: dict[str, dict] = self._config["providers"]
         self._retry_defaults: dict = self._config.get("retry_defaults", {})

--- a/lightroom_tagger/core/provider_registry.py
+++ b/lightroom_tagger/core/provider_registry.py
@@ -18,6 +18,7 @@ class ProviderRegistry:
     """Central registry of vision/LLM providers and their models."""
 
     def __init__(self, config_path: Path = _CONFIG_PATH):
+        self._config_path = config_path
         with open(config_path) as f:
             self._config: dict[str, Any] = json.load(f)
         self._providers: dict[str, dict] = self._config["providers"]
@@ -34,11 +35,11 @@ class ProviderRegistry:
 
     def list_providers(self) -> list[dict]:
         result = []
-        for pid, pconfig in self._providers.items():
+        for provider_id, provider_config in self._providers.items():
             result.append({
-                "id": pid,
-                "name": pconfig["name"],
-                "available": self._is_available(pid, pconfig),
+                "id": provider_id,
+                "name": provider_config["name"],
+                "available": self._is_available(provider_id, provider_config),
             })
         return result
 
@@ -46,22 +47,22 @@ class ProviderRegistry:
         if provider_id not in self._providers:
             raise KeyError(f"Unknown provider: {provider_id}")
 
-        pconfig = self._providers[provider_id]
+        provider_config = self._providers[provider_id]
         models: list[dict] = []
 
-        for m in pconfig.get("models", []):
-            models.append({**m, "source": "config"})
+        for model_entry in provider_config.get("models", []):
+            models.append({**model_entry, "source": "config"})
 
-        if pconfig.get("auto_discover"):
-            models.extend(self._discover_models(provider_id, pconfig))
+        if provider_config.get("auto_discover"):
+            models.extend(self._discover_models(provider_id, provider_config))
 
         return models
 
     def get_client(self, provider_id: str) -> openai.OpenAI:
-        pconfig = self._providers[provider_id]
-        base_url = self._resolve_base_url(pconfig)
-        api_key = self._resolve_api_key(pconfig)
-        extra_headers = pconfig.get("extra_headers", {})
+        provider_config = self._providers[provider_id]
+        base_url = self._resolve_base_url(provider_config)
+        api_key = self._resolve_api_key(provider_config)
+        extra_headers = provider_config.get("extra_headers", {})
         client = openai.OpenAI(
             base_url=base_url,
             api_key=api_key,
@@ -71,15 +72,49 @@ class ProviderRegistry:
         return client
 
     def get_retry_config(self, provider_id: str) -> dict:
-        pconfig = self._providers[provider_id]
-        provider_retry = pconfig.get("retry", {})
+        provider_config = self._providers[provider_id]
+        provider_retry = provider_config.get("retry", {})
         merged = {**self._retry_defaults, **provider_retry}
         return merged
 
-    def _is_available(self, provider_id: str, pconfig: dict) -> bool:
-        if "api_key" in pconfig:
+    def update_fallback_order(self, order: list[str]) -> None:
+        if not order:
+            raise ValueError("fallback order must not be empty")
+        unknown = [provider_id for provider_id in order if provider_id not in self._providers]
+        if unknown:
+            raise ValueError(f"Unknown provider id(s): {unknown!r}")
+        self._config["fallback_order"] = list(order)
+        self._save_config()
+
+    def update_defaults(self, defaults: dict) -> None:
+        allowed_keys = frozenset({"vision_comparison", "description"})
+        if not defaults:
+            raise ValueError(
+                "defaults must include at least one of vision_comparison, description"
+            )
+        for key, value in defaults.items():
+            if key not in allowed_keys:
+                raise ValueError(f"Unknown defaults key: {key!r}")
+            if not isinstance(value, dict):
+                raise ValueError(f"{key} must be an object")
+            if "provider" not in value:
+                raise ValueError(f"{key} requires provider")
+            provider_id = value["provider"]
+            if provider_id not in self._providers:
+                raise ValueError(f"Unknown provider: {provider_id}")
+        merged = {**self._config.get("defaults", {}), **defaults}
+        self._config["defaults"] = merged
+        self._save_config()
+
+    def _save_config(self) -> None:
+        with open(self._config_path, "w", encoding="utf-8") as f:
+            json.dump(self._config, f, indent=2, ensure_ascii=False)
+            f.write("\n")
+
+    def _is_available(self, provider_id: str, provider_config: dict) -> bool:
+        if "api_key" in provider_config:
             return True
-        api_key_env = pconfig.get("api_key_env")
+        api_key_env = provider_config.get("api_key_env")
         if api_key_env:
             return bool(os.environ.get(api_key_env))
         return False
@@ -97,17 +132,17 @@ class ProviderRegistry:
             return base
         return default
 
-    def _resolve_api_key(self, pconfig: dict) -> str:
-        if "api_key" in pconfig:
-            return pconfig["api_key"]
-        env_var = pconfig.get("api_key_env")
+    def _resolve_api_key(self, provider_config: dict) -> str:
+        if "api_key" in provider_config:
+            return provider_config["api_key"]
+        env_var = provider_config.get("api_key_env")
         return os.environ.get(env_var, "") if env_var else ""
 
-    def _discover_models(self, provider_id: str, pconfig: dict) -> list[dict]:
+    def _discover_models(self, provider_id: str, provider_config: dict) -> list[dict]:
         if provider_id in self._discovered_cache:
             return self._discovered_cache[provider_id]
 
-        base_url = self._resolve_base_url(pconfig)
+        base_url = self._resolve_base_url(provider_config)
         tags_url = base_url.replace("/v1", "/api/tags")
 
         try:
@@ -118,10 +153,10 @@ class ProviderRegistry:
             return []
 
         models = []
-        for m in data.get("models", []):
+        for discovered_model in data.get("models", []):
             models.append({
-                "id": m["name"],
-                "name": m["name"],
+                "id": discovered_model["name"],
+                "name": discovered_model["name"],
                 "vision": True,
                 "source": "discovered",
             })

--- a/lightroom_tagger/core/provider_registry.py
+++ b/lightroom_tagger/core/provider_registry.py
@@ -83,7 +83,13 @@ class ProviderRegistry:
         unknown = [provider_id for provider_id in order if provider_id not in self._providers]
         if unknown:
             raise ValueError(f"Unknown provider id(s): {unknown!r}")
-        self._config["fallback_order"] = list(order)
+        seen_provider_ids: set[str] = set()
+        deduplicated_order: list[str] = []
+        for provider_id in order:
+            if provider_id not in seen_provider_ids:
+                seen_provider_ids.add(provider_id)
+                deduplicated_order.append(provider_id)
+        self._config["fallback_order"] = deduplicated_order
         self._save_config()
 
     def update_defaults(self, defaults: dict) -> None:

--- a/lightroom_tagger/core/provider_registry.py
+++ b/lightroom_tagger/core/provider_registry.py
@@ -125,12 +125,12 @@ class ProviderRegistry:
             return bool(os.environ.get(api_key_env))
         return False
 
-    def _resolve_base_url(self, pconfig: dict) -> str:
-        if "base_url" in pconfig:
-            return pconfig["base_url"]
-        env_var = pconfig.get("base_url_env")
+    def _resolve_base_url(self, provider_config: dict) -> str:
+        if "base_url" in provider_config:
+            return provider_config["base_url"]
+        env_var = provider_config.get("base_url_env")
         host = os.environ.get(env_var, "") if env_var else ""
-        default = pconfig.get("base_url_default", "")
+        default = provider_config.get("base_url_default", "")
         if host:
             base = host.rstrip("/")
             if not base.endswith("/v1"):


### PR DESCRIPTION
## SUMMARY

Provider config page fully functional :)
Wires up all the missing UI interactions from the initial provider registry PR — model selection, fallback reordering, and user model management.

## DETAILS

- Wire `ProviderModelSelect` into MatchingPage and DescriptionsPage via shared `matchOptionsContext` (single source of truth, no duplicated state)
- Make `FallbackOrderPanel` editable with up/down reorder buttons, persisted via `PUT /providers/fallback-order`
- Add `AddModelForm` + `ModelList` components for per-provider user model CRUD on the Providers page
- Backend mutation endpoints: `PUT /fallback-order`, `PUT /defaults`, `POST/DELETE /<provider>/models`
- Unify `/vision-models` to aggregate models from `ProviderRegistry` across all available providers (replaces old `ollama list` subprocess)
- `provider_models` SQLite table for user-added models
- Fix 2 pre-existing test failures: `test_db_utils` (stale TinyDB mock) and `test_get_active_jobs` (wrong assertion on pending jobs)
- Rename shorthand variables throughout (pid, pconfig, opts, vc, um, etc.) for readability
- 20 new backend tests covering all mutation endpoints, vision-models aggregation, and user model CRUD

## DEVELOPER IMPACT

Provider selection now flows through `matchOptionsContext` — both MatchingPage and DescriptionsPage read from the same context. No more local provider state duplication.

## TESTING

- 154 core tests passing
- 74 backend tests passing (0 failures, previously had 2 pre-existing failures now fixed)
- TypeScript compiles cleanly

## DOCUMENTATION

N/A

## PIC

![providers go brrr](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExNjRhOGU3bGdtZ3E5Mm5rYmxqOHk2cjJ4azI2dDRzamRoeG5kbWJhdiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/LmNwDtLy4Q3lwCyWay/giphy.gif)