### PR TITLE
Fix Sandcastle PRD guard + document ready-for-agent as build trigger

### DIFF
--- a/.github/workflows/sandcastle.yml
+++ b/.github/workflows/sandcastle.yml
@@ -20,7 +20,7 @@ jobs:
   run:
     if: >-
       contains(fromJSON('["sandcastle","ready-for-agent"]'), github.event.label.name)
-      && !startsWith(github.event.issue.title, 'PRD:')
+      && !startsWith(github.event.issue.title, '[PRD]')
     runs-on: ubuntu-latest
     env:
       BRANCH: sandcastle/issue-${{ github.event.issue.number }}

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -21,3 +21,25 @@ See `docs/agents/triage-labels.md` for the canonical label vocabulary.
 - One issue per bug or feature
 - Link PRs to issues with `Closes #<number>` in the PR body
 - Use issue comments for status updates rather than editing the body
+
+## PRD lifecycle
+
+Issues progress from raw idea → grilled PRD → ready to implement. The title prefix signals the state:
+
+- **No prefix** — an ungrilled idea/seed. The body is a short stub and is not yet implementation-ready.
+- **`[PRD]` prefix** — the issue has been grilled (e.g. via `/grill-with-docs`) into a full PRD body. A PRD is a **spec, not a task**: it is broken into implementation issues (via `/to-issues`) rather than built directly. Add the prefix **only** once the body has the PRD shape (Problem / Goal or Solution / Scope / Acceptance criteria / Out of scope).
+
+Rules:
+
+- Adding `[PRD]` and the PRD-shaped body go together — don't prefix a thin stub.
+- Editing an issue body to author/refine its PRD is expected and is **not** a "status update" (the comments-not-body convention above applies to status, not to PRD authoring).
+- When you migrate a backlog/seed item into its own issue, leave it unprefixed until it's grilled.
+
+## `ready-for-agent` and Sandcastle
+
+**`ready-for-agent` is the Sandcastle trigger.** Adding it to an issue (see `.github/workflows/sandcastle.yml`) fires an AFK agent that implements the issue and opens a PR. Treat the label as "build this now," not merely "specified."
+
+Consequences:
+
+- **Never put `ready-for-agent` on a `[PRD]` issue.** A PRD is a spec — labeling it makes Sandcastle try to build the whole PRD in one PR. As a safeguard, Sandcastle also skips any issue whose title starts with `[PRD]`, but don't rely on that: keep PRDs unlabeled.
+- **Sandcastle has no dependency awareness.** It fires immediately on the label and ignores an issue's "Blocked by" section. So label **one unblocked slice at a time** — add `ready-for-agent` to the next slice only after its blocker's PR has merged. Labeling a whole dependency chain at once runs every slice in parallel, out of order.


### PR DESCRIPTION
## Problem

Sandcastle triggers on the `ready-for-agent` label and is supposed to skip PRD spec issues, but the guard checked for titles starting with `PRD:` while the actual (and documented) convention is `[PRD]`. So grilled PRDs slipped through and Sandcastle built the entire spec in a single PR.

## Changes

- **`.github/workflows/sandcastle.yml`** — align the skip guard to `[PRD]` (was `PRD:`), so PRD-titled issues are correctly skipped even if labeled `ready-for-agent`.
- **`docs/agents/issue-tracker.md`** — document that `ready-for-agent` *is* the Sandcastle "build now" trigger:
  - never apply it to a `[PRD]` issue (a PRD is a spec, broken into implementation issues via `/to-issues`);
  - Sandcastle has no dependency awareness, so label **one unblocked slice at a time** — add the label to the next slice only after its blocker's PR merges.

## Notes

Not a behavior change to the build pipeline itself — just the trigger guard and the process docs. Verified against the incident where PRDs #38/#40 each spawned a whole-spec PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)