### PR TITLE
Sandcastle: verify OpenAPI contract in-pipeline (agents self-correct drift)

### DIFF
--- a/.sandcastle/Dockerfile
+++ b/.sandcastle/Dockerfile
@@ -43,6 +43,15 @@ WORKDIR /home/agent/.deps
 COPY pyproject.toml uv.lock ./
 RUN uv sync --frozen --no-install-project --extra dev
 
+# Pre-bake the frontend deps too (same rationale: fast, offline; layer caches on
+# the manifests). Baked outside the bind-mounted workspace; a runtime hook
+# symlinks node_modules into the worktree so the contract check (generate:api +
+# tsc) can run. Skip Playwright's browser download — the check needs none.
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+WORKDIR /home/agent/.fe-deps
+COPY apps/visualizer/frontend/package.json apps/visualizer/frontend/package-lock.json ./
+RUN npm ci --legacy-peer-deps --no-audit --no-fund
+
 WORKDIR /home/agent
 
 # In worktree sandbox mode, Sandcastle bind-mounts the git worktree at /home/agent/workspace

--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -16,7 +16,12 @@ const task = process.env.SANDCASTLE_TASK?.trim();
 
 const commitNote =
   "When done and tests pass, stage and commit ALL changes " +
-  '(`git add -A && git commit -m "..."`), then output <promise>COMPLETE</promise>.';
+  '(`git add -A && git commit -m "..."`), then output <promise>COMPLETE</promise>. ' +
+  "IMPORTANT: if you changed any backend response model (`apps/visualizer/backend/api/schemas/**`) " +
+  "or a route's `@spec.validate` decorator, first run " +
+  "`cd apps/visualizer/frontend && npm run generate:api` and commit the regenerated " +
+  "`src/types/api.gen.ts` (a committed CI gate fails on drift). Never put `@spec.validate` " +
+  "on a `send_file`/binary route.";
 
 // Two-axis review (ported from the code-review skill): Spec = does the diff
 // match what was asked; Standards = does it follow repo conventions + the
@@ -53,6 +58,15 @@ Then scan for these code smells — judgement calls, not hard rules; a documente
 ## Tests
 Ensure coverage is adequate and the suite passes: \`python -m pytest -q\`.
 
+## Contract (backend-authoritative OpenAPI → generated TS)
+This repo generates the frontend's types from the backend OpenAPI spec (ADR-0013); the generated file \`apps/visualizer/frontend/src/types/api.gen.ts\` is committed and a CI gate fails on drift. If the diff touches ANY pydantic response model (\`backend/api/schemas/**\`) or a route's \`@spec.validate\` decorator, the committed types may be stale. Verify and FIX before finishing:
+
+- \`cd apps/visualizer/frontend && npm run generate:api\` — regenerate the committed types.
+- \`git diff --exit-code src/types/api.gen.ts\` must be clean afterwards. If it is not, the regen changed the file → **commit the regenerated \`api.gen.ts\`** (this is the #1 cause of gate failures — do not skip it).
+- \`npx tsc --noEmit\` must pass.
+
+Also: never wrap a \`send_file\`/binary/streaming route in \`@spec.validate\` — validation reads the response body and 500s with "direct passthrough mode". Binary endpoints do not belong in the JSON contract.
+
 ## Done
 Fix the issues you find directly and keep fixes minimal. Then stage and commit ALL changes (including the implementer's work if still uncommitted):
 \`git add -A && git commit -m "Review + fixes"\`
@@ -70,6 +84,9 @@ await using sandbox = await createSandbox({
         { command: "git config user.email agent@sandcastle.local" },
         { command: "git config user.name 'Sandcastle Agent'" },
         { command: "uv pip install -e . --no-deps" },
+        // Link the pre-baked frontend deps into the worktree so the contract
+        // check (npm run generate:api + tsc) can run without a per-run npm ci.
+        { command: "ln -sfn /home/agent/.fe-deps/node_modules apps/visualizer/frontend/node_modules" },
       ],
     },
   },

--- a/.sandcastle/prompt.md
+++ b/.sandcastle/prompt.md
@@ -13,6 +13,20 @@ Recent history:
 
 <!-- Describe what the agent should do. Replace this section before running locally. -->
 
+# Contract (OpenAPI → generated TS)
+
+The visualizer's frontend types are generated from the backend OpenAPI spec
+(ADR-0013); `apps/visualizer/frontend/src/types/api.gen.ts` is committed and a CI
+gate fails on drift. If you touch a pydantic response model
+(`apps/visualizer/backend/api/schemas/**`) or a route's `@spec.validate`
+decorator, you MUST regenerate and commit the types:
+
+    cd apps/visualizer/frontend && npm run generate:api   # then commit src/types/api.gen.ts
+    npx tsc --noEmit                                       # must pass
+
+Never wrap a `send_file`/binary/streaming route in `@spec.validate` — it 500s
+with "direct passthrough mode". Binary endpoints are not part of the JSON contract.
+
 # Done
 
 The project and its dev deps are already installed in the active venv, so run
@@ -20,7 +34,8 @@ the test suite with:
 
 !`echo "Run: python -m pytest -q"`
 
-When the task is complete and tests pass, stage and commit ALL your changes:
+When the task is complete and tests pass, stage and commit ALL your changes
+(including any regenerated `api.gen.ts`):
 
     git add -A && git commit -m "..."
 


### PR DESCRIPTION
## Why
Third maintainer-intervention in a row (#151 needed a manual `api.gen.ts` regen). Root cause: the Sandcastle pipeline only runs `pytest` — it never runs the contract checks (`generate:api` drift + `tsc`), so the agent can't see stale generated types. They only surface in the separate `pull_request` drift gate *after* the PR opens, which also doesn't auto-trigger on App-authored PRs.

## What
Shift the contract check left into the agent's own run so it fails and self-corrects before opening a PR:
- **Dockerfile** — pre-bake frontend deps (`npm ci`, Playwright browser download skipped), same fast/offline pattern as the Python deps.
- **main.mts** — symlink the baked `node_modules` into the worktree on start; add a **Contract** step to the reviewer (regenerate `api.gen.ts` → `git diff --exit-code` → `tsc`, commit the regen) and a matching line to the implementer commit note.
- **prompt.md** — document the rule: regenerate+commit `api.gen.ts` after any response-model/`@spec.validate` change; never `@spec.validate` a `send_file`/binary route.

## Effect
Catches the two classes we hit — drift (#148, #151) and send_file-in-validation (#150) — inside the agent run instead of via post-hoc maintainer fixes.

## Validation
- `npm run verify:contract` passes clean on master (exit 0).
- `main.mts` parses (`node --check`).
- Full validation is the next Sandcastle run — this config only takes effect once merged (the `.sandcastle/` image/pipeline is read at issue-label time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)