### PR TITLE
Post-merge review fixes for PRD #184: decouple catalog list path from the description blob

### DIFF
--- a/apps/visualizer/backend/api/images/catalog.py
+++ b/apps/visualizer/backend/api/images/catalog.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import os
 import re
 from collections.abc import Sequence
@@ -17,25 +16,26 @@ from api.openapi import spec
 from api.schemas.catalog import (
     CatalogListResponse,
     CatalogMonthsResponse,
-    CatalogSimilarResponse,
     CatalogSimilarityGroupsResponse,
+    CatalogSimilarResponse,
     ImageView,
 )
 from api.schemas.jobs import ErrorBody
-
 from lightroom_tagger.core.clip_similarity import NoClipEmbeddingError, run_clip_similar_for_seed
 from lightroom_tagger.core.database import (
     catalog_image_stack_row_fields,
-    get_catalog_months as list_catalog_months,
+    get_best_current_catalog_score,
     get_catalog_similarity_groups_paginated,
     get_current_scores_for_image,
-    get_best_current_catalog_score,
     get_image,
     get_image_description,
     get_similarity_candidates_for_group,
     get_vision_cached_image,
     query_catalog_images,
     query_catalog_images_by_keys,
+)
+from lightroom_tagger.core.database import (
+    get_catalog_months as list_catalog_months,
 )
 from lightroom_tagger.core.identity_service import compute_single_image_aggregate_scores
 
@@ -174,15 +174,13 @@ def _parse_clip_similar_catalog_params():
     }
 
 
-def _rows_to_catalog_api_images(rows, score_perspective_arg: str | None) -> list[dict]:
+def _rows_to_catalog_api_images(rows) -> list[dict]:
     """Transform ``query_catalog_images`` rows to API image dicts (catalog list + NL search)."""
-    del score_perspective_arg  # best-score fields are always computed in the list query
     images: list[dict] = []
     for row in rows:
         out = dict(row)
         desc_summary = out.pop("description_summary", None)
         desc_best = out.pop("description_best_perspective", None)
-        desc_perspectives_json = out.pop("description_perspectives_json", None)
 
         cps = out.pop("catalog_perspective_score", None)
         out["catalog_perspective_score"] = int(cps) if cps is not None else None
@@ -196,17 +194,9 @@ def _rows_to_catalog_api_images(rows, score_perspective_arg: str | None) -> list
         if ai_analyzed:
             out["description_summary"] = desc_summary or ""
             out["description_best_perspective"] = desc_best or ""
-            if desc_perspectives_json:
-                try:
-                    out["description_perspectives"] = json.loads(desc_perspectives_json)
-                except (json.JSONDecodeError, TypeError):
-                    out["description_perspectives"] = {}
-            else:
-                out["description_perspectives"] = {}
         else:
             out["description_summary"] = None
             out["description_best_perspective"] = None
-            out["description_perspectives"] = None
 
         rid = out.get("id")
         if rid is not None and str(rid).strip().isdigit():
@@ -437,7 +427,7 @@ def list_catalog_images(db):
         except ValueError as err:
             return error_bad_request(str(err))
 
-        images = _rows_to_catalog_api_images(rows, score_perspective_arg)
+        images = _rows_to_catalog_api_images(rows)
 
         return jsonify(
             {
@@ -493,7 +483,7 @@ def get_catalog_image_similar(db, image_key: str):
         catalog_rows = query_catalog_images_by_keys(
             db, keys, score_perspective=score_perspective_arg
         )
-        images = _rows_to_catalog_api_images(catalog_rows, score_perspective_arg)
+        images = _rows_to_catalog_api_images(catalog_rows)
         dist_by_key = {k: float(d) for k, d in page_pairs}
         for img in images:
             d = dist_by_key.get(img["key"], 0.0)
@@ -531,13 +521,13 @@ def list_catalog_similarity_groups(db):
         for group in groups:
             seed_key = str(group["seed_key"])
             seed_rows = query_catalog_images_by_keys(db, [seed_key])
-            seed_images = _rows_to_catalog_api_images(seed_rows, None)
+            seed_images = _rows_to_catalog_api_images(seed_rows)
             if not seed_images:
                 continue
             candidate_rows = get_similarity_candidates_for_group(db, int(group["group_id"]))
             candidate_keys = [str(r["candidate_key"]) for r in candidate_rows]
             catalog_rows = query_catalog_images_by_keys(db, candidate_keys)
-            candidates = _rows_to_catalog_api_images(catalog_rows, None)
+            candidates = _rows_to_catalog_api_images(catalog_rows)
             by_key = {img["key"]: img for img in candidates}
             ordered_candidates = []
             for row in candidate_rows:

--- a/apps/visualizer/backend/api/images/search.py
+++ b/apps/visualizer/backend/api/images/search.py
@@ -30,16 +30,8 @@ from .common import _clamp_pagination
 search_bp = Blueprint("images_search", __name__)
 
 
-def _score_perspective_from_filters(filters: dict | None) -> str | None:
-    if not filters:
-        return None
-    sp = str(filters.get("score_perspective") or "").strip()
-    return sp or None
-
-
 def _catalog_rows_with_signals(
     result_images: list[dict],
-    score_perspective_arg: str | None,
 ) -> list[dict]:
     """Map core rows to API images, merging semantic score / why_matched / thumbnail_url."""
     catalog_rows: list[dict] = []
@@ -54,7 +46,7 @@ def _catalog_rows_with_signals(
             }
         catalog_rows.append(r)
 
-    images = _rows_to_catalog_api_images(catalog_rows, score_perspective_arg)
+    images = _rows_to_catalog_api_images(catalog_rows)
     for img in images:
         sig = signals_by_key.get(img["key"])
         if sig is not None and sig.get("score") is not None:
@@ -109,8 +101,7 @@ def nl_search_images(db):
         except CatalogSearchInputError as exc:
             return error_bad_request(str(exc))
 
-        score_perspective_arg = _score_perspective_from_filters(result.filters)
-        images = _rows_to_catalog_api_images(result.images, score_perspective_arg)
+        images = _rows_to_catalog_api_images(result.images)
         return jsonify(
             {
                 "filters": result.filters,
@@ -154,7 +145,7 @@ def semantic_search_images(db):
         except CatalogSearchInputError as exc:
             return error_bad_request(str(exc))
 
-        images = _catalog_rows_with_signals(result.images, score_perspective_arg)
+        images = _catalog_rows_with_signals(result.images)
 
         return jsonify(
             {
@@ -230,13 +221,12 @@ def chat_search_images(db):
             return error_bad_request(str(exc))
 
         if result.mode in ("semantic", "tool_calling"):
-            images = _catalog_rows_with_signals(result.images, score_perspective_arg)
+            images = _catalog_rows_with_signals(result.images)
             if result.mode == "tool_calling":
                 for img in images:
                     img["thumbnail_url"] = f"/api/images/catalog/{img['key']}/thumbnail"
         else:
-            sp_from_filter = _score_perspective_from_filters(result.filters)
-            images = _rows_to_catalog_api_images(result.images, sp_from_filter)
+            images = _rows_to_catalog_api_images(result.images)
 
         payload: dict[str, Any] = {
             "search_mode": result.mode,

--- a/apps/visualizer/backend/api/images/stacks.py
+++ b/apps/visualizer/backend/api/images/stacks.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from flask import Blueprint, jsonify, request
 from spectree import Response
-
 from utils.db import with_db
 from utils.responses import error_bad_request, error_not_found, error_server_error
 
@@ -19,7 +18,6 @@ from api.schemas.stacks import (
     StackSplitMemberRequest,
     StackSplitMemberResponse,
 )
-
 from lightroom_tagger.core.database import (
     StackMutationError,
     library_write,
@@ -54,7 +52,7 @@ def get_stack_members(db, stack_id: int):
             return jsonify({"items": []})
 
         catalog_rows = _query_catalog_rows_for_stack_member_keys(db, keys, score_perspective=None)
-        items = _rows_to_catalog_api_images(catalog_rows, None)
+        items = _rows_to_catalog_api_images(catalog_rows)
         for it in items:
             it["thumbnail_url"] = f"/api/images/catalog/{it['key']}/thumbnail"
         return jsonify({"items": items})

--- a/apps/visualizer/backend/api/schemas/catalog.py
+++ b/apps/visualizer/backend/api/schemas/catalog.py
@@ -46,7 +46,6 @@ class CatalogImage(BaseModel):
     ai_analyzed: bool | None = None
     description_summary: str | None = None
     description_best_perspective: str | None = None
-    description_perspectives: dict[str, Any] | None = None
     catalog_perspective_score: int | None = None
     catalog_score_perspective: str | None = None
     stack_id: int | None = None

--- a/apps/visualizer/backend/tests/test_catalog_contract.py
+++ b/apps/visualizer/backend/tests/test_catalog_contract.py
@@ -85,7 +85,7 @@ def test_rows_to_catalog_api_images_round_trip(catalog_contract_client):
     conn = init_database(db_path)
     try:
         rows, _total = query_catalog_images(conn)
-        images = _rows_to_catalog_api_images(rows, None)
+        images = _rows_to_catalog_api_images(rows)
         assert images
         validated = CatalogImage.model_validate(validate_catalog_image(images[0]))
         assert validated.filename

--- a/apps/visualizer/backend/tests/test_images_catalog_api.py
+++ b/apps/visualizer/backend/tests/test_images_catalog_api.py
@@ -167,6 +167,8 @@ def test_catalog_analyzed_filter_and_embedded_description(catalog_analyzed_clien
     probe = next(img for img in data["images"] if img["key"] == image_key)
     assert probe["ai_analyzed"] is True
     assert probe["description_summary"] == "probe-summary"
+    # LIST path is fully decoupled from the description blob's per-perspective scores.
+    assert "description_perspectives" not in probe
 
     resp = client.get("/api/images/catalog?analyzed=false")
     assert resp.status_code == 200

--- a/apps/visualizer/frontend/src/types/api.gen.ts
+++ b/apps/visualizer/frontend/src/types/api.gen.ts
@@ -3550,13 +3550,6 @@ export interface components {
              */
             description_best_perspective: string | null;
             /**
-             * Description Perspectives
-             * @default null
-             */
-            description_perspectives: {
-                [key: string]: unknown;
-            } | null;
-            /**
              * Catalog Perspective Score
              * @default null
              */
@@ -3791,13 +3784,6 @@ export interface components {
              * @default null
              */
             description_best_perspective: string | null;
-            /**
-             * Description Perspectives
-             * @default null
-             */
-            description_perspectives: {
-                [key: string]: unknown;
-            } | null;
             /**
              * Catalog Perspective Score
              * @default null
@@ -4047,13 +4033,6 @@ export interface components {
              * @default null
              */
             description_best_perspective: string | null;
-            /**
-             * Description Perspectives
-             * @default null
-             */
-            description_perspectives: {
-                [key: string]: unknown;
-            } | null;
             /**
              * Catalog Perspective Score
              * @default null
@@ -4593,13 +4572,6 @@ export interface components {
              */
             description_best_perspective: string | null;
             /**
-             * Description Perspectives
-             * @default null
-             */
-            description_perspectives: {
-                [key: string]: unknown;
-            } | null;
-            /**
              * Catalog Perspective Score
              * @default null
              */
@@ -4834,13 +4806,6 @@ export interface components {
              * @default null
              */
             description_best_perspective: string | null;
-            /**
-             * Description Perspectives
-             * @default null
-             */
-            description_perspectives: {
-                [key: string]: unknown;
-            } | null;
             /**
              * Catalog Perspective Score
              * @default null
@@ -5125,13 +5090,6 @@ export interface components {
              */
             description_best_perspective: string | null;
             /**
-             * Description Perspectives
-             * @default null
-             */
-            description_perspectives: {
-                [key: string]: unknown;
-            } | null;
-            /**
              * Catalog Perspective Score
              * @default null
              */
@@ -5366,13 +5324,6 @@ export interface components {
              * @default null
              */
             description_best_perspective: string | null;
-            /**
-             * Description Perspectives
-             * @default null
-             */
-            description_perspectives: {
-                [key: string]: unknown;
-            } | null;
             /**
              * Catalog Perspective Score
              * @default null

--- a/lightroom_tagger/core/database/catalog_query.py
+++ b/lightroom_tagger/core/database/catalog_query.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 import sqlite3
 from collections.abc import Collection, Sequence
 
-from lightroom_tagger.core.database.catalog_query_filters import (
-    _append_query_catalog_image_filters,
-    _non_empty_str_list_for_json_array_filter,
-)
 from lightroom_tagger.core.database.catalog_query_best_score import (
     CATALOG_BEST_SCORE_JOIN_SQL,
     CATALOG_BEST_SCORE_SELECT_COLS,
+)
+from lightroom_tagger.core.database.catalog_query_filters import (
+    _append_query_catalog_image_filters,
+    _non_empty_str_list_for_json_array_filter,
 )
 from lightroom_tagger.core.database.db_init import _deserialize_row
 
@@ -236,7 +236,6 @@ def query_catalog_images(
     select_cols = (
         "i.*, d.summary AS description_summary, "
         "d.best_perspective AS description_best_perspective, "
-        "d.perspectives AS description_perspectives_json, "
         f"{CATALOG_BEST_SCORE_SELECT_COLS}, "
         "st.stack_id AS stack_id, st.stack_size AS stack_member_count, "
         "CASE WHEN st.stack_id IS NOT NULL AND i.key = st.representative_key "
@@ -288,7 +287,6 @@ def query_catalog_images_by_keys(
     select_cols = (
         "i.*, d.summary AS description_summary, "
         "d.best_perspective AS description_best_perspective, "
-        "d.perspectives AS description_perspectives_json, "
         f"{CATALOG_BEST_SCORE_SELECT_COLS}, "
         "st.stack_id AS stack_id, st.stack_size AS stack_member_count, "
         "CASE WHEN st.stack_id IS NOT NULL AND i.key = st.representative_key "

--- a/lightroom_tagger/core/database/catalog_query_best_score.py
+++ b/lightroom_tagger/core/database/catalog_query_best_score.py
@@ -4,7 +4,22 @@ from __future__ import annotations
 
 import sqlite3
 
-CATALOG_BEST_SCORE_JOIN_SQL = """
+# Single source of truth for winner selection: a correlated ``NOT EXISTS``
+# that keeps only the row ``s1`` for which no other current catalog score
+# ``s2`` ranks higher. Higher score wins; ties break toward the
+# lexicographically smallest ``perspective_slug``. Referenced from both the
+# list-query JOIN and the single-image lookup so the tie-break lives in one place.
+_BEST_SCORE_TIEBREAK_PREDICATE = """NOT EXISTS (
+    SELECT 1 FROM image_scores s2
+    WHERE s2.image_key = s1.image_key
+      AND s2.image_type = 'catalog' AND s2.is_current = 1
+      AND (
+        s2.score > s1.score
+        OR (s2.score = s1.score AND s2.perspective_slug < s1.perspective_slug)
+      )
+)"""
+
+CATALOG_BEST_SCORE_JOIN_SQL = f"""
 LEFT JOIN (
     SELECT
         s1.image_key,
@@ -12,15 +27,7 @@ LEFT JOIN (
         s1.perspective_slug AS best_perspective_slug
     FROM image_scores s1
     WHERE s1.image_type = 'catalog' AND s1.is_current = 1
-      AND NOT EXISTS (
-        SELECT 1 FROM image_scores s2
-        WHERE s2.image_key = s1.image_key
-          AND s2.image_type = 'catalog' AND s2.is_current = 1
-          AND (
-            s2.score > s1.score
-            OR (s2.score = s1.score AND s2.perspective_slug < s1.perspective_slug)
-          )
-      )
+      AND {_BEST_SCORE_TIEBREAK_PREDICATE}
 ) best_s ON best_s.image_key = i.key
 """
 
@@ -38,22 +45,13 @@ def get_best_current_catalog_score(
     Ties on score break toward the lexicographically smallest ``perspective_slug``.
     """
     row = db.execute(
-        """
+        f"""
         SELECT s1.score, s1.perspective_slug
         FROM image_scores s1
         WHERE s1.image_key = ?
           AND s1.image_type = 'catalog'
           AND s1.is_current = 1
-          AND NOT EXISTS (
-            SELECT 1 FROM image_scores s2
-            WHERE s2.image_key = s1.image_key
-              AND s2.image_type = 'catalog'
-              AND s2.is_current = 1
-              AND (
-                s2.score > s1.score
-                OR (s2.score = s1.score AND s2.perspective_slug < s1.perspective_slug)
-              )
-          )
+          AND {_BEST_SCORE_TIEBREAK_PREDICATE}
         LIMIT 1
         """,
         (image_key,),


### PR DESCRIPTION
Follow-up to the four merged slices of **PRD #184** (single source of truth for perspective scores = `image_scores`): #190 (slice 1 backfill + ADR-0016), #191 (slice 2 description prose-only), #192 (slice 3 grid best-score), #193 (slice 4 modal split + cleanup).

I ran a two-axis (**Spec** + **Standards**) `/code-review` over the combined range `01c4131...HEAD` using parallel subagents. The slices were implemented faithfully — this PR fixes the gaps that survived.

## Spec gap — acceptance criterion 6 was PARTIAL
Criterion 6: *"`description_perspectives` removed from the detail API."* The **detail** path was clean, but the **list** path still emitted `description_perspectives` from the description blob (`_rows_to_catalog_api_images`, `CatalogImage` schema). It was dead on the wire (no frontend consumer) but kept the list transform coupled to the blob — contradicting the goal *"no dependence on the description blob."* Removed end to end:

- `catalog_query.py` — dropped `d.perspectives AS description_perspectives_json` from both list SELECTs. **Kept** `description_best_perspective` (still consumed by `adapters.ts:49`).
- `catalog.py` `_rows_to_catalog_api_images` — stopped populating `description_perspectives`; removed the now-dead `score_perspective_arg` parameter (best-score is computed unconditionally since slice 3) and the unused `import json`.
- `api/schemas/catalog.py` — removed the `description_perspectives` field from `CatalogImage`.
- `api.gen.ts` — **regenerated** (ADR-0013, not hand-edited): pure removal of the field across all 7 `CatalogImage`-shaped endpoints, zero additions.
- Ripple: `search.py` / `stacks.py` call sites updated; dead `_score_perspective_from_filters` helper removed.

## Standards
- **Duplicated Code** — `catalog_query_best_score.py` had the best-score tie-break `NOT EXISTS (...)` predicate written twice (JOIN SQL + `get_best_current_catalog_score`). Extracted into a single `_BEST_SCORE_TIEBREAK_PREDICATE` constant referenced by both. Pure refactor, identical SQL semantics.

## Deliberately NOT changed (judgement calls)
- **Migration placement** — the backfill migration lives in `scores.py` rather than `db_init_migrations.py` (a convention nit). Moving a merged, tested, `user_version`-gated migration across modules risks the version sequence for a cosmetic gain; left as-is.
- `image_descriptions.perspectives` **column** retained per the PRD (deferred drop).

## Verification
- Added a list-path test asserting `description_perspectives` is absent (mirrors the detail assertion).
- Backend touched-area suite: **green** (56 passed). Frontend `tsc --noEmit`: **clean**. Component tests (PrimaryScorePill, CatalogImageDetailSections): **6 passed**. `ruff` clean on all touched files.

## ⚠️ Heads-up — pre-existing failures (out of scope)
`test_matches_api_pin.py::test_validate_match_response_pinned` and `::test_reject_match_response_pinned` fail on `origin/master` **and at the base commit `01c4131`** — they predate all PRD #184 work. Not touched here; flagging so they can be triaged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)