### PR TITLE
Scoring: persist under the requested perspective on slug mismatch

### DIFF
--- a/lightroom_tagger/core/scoring_service.py
+++ b/lightroom_tagger/core/scoring_service.py
@@ -103,23 +103,22 @@ def _run_score_persist(
         silent_compression=silent_compression,
     )
 
-    reject_reason: dict[str, str] = {}
-
     def accept_result(parsed_bundle: tuple) -> bool:
         parsed, _repaired = parsed_bundle
         got_slug = _normalize_perspective_slug(parsed.perspective_slug)
-        if got_slug != perspective_slug.strip():
-            if log_callback:
-                log_callback(
-                    "warning",
-                    f"Slug mismatch: model returned {parsed.perspective_slug!r}, "
-                    f"normalized to {got_slug!r}, expected {perspective_slug!r} — skipping",
-                )
-            reject_reason["msg"] = (
-                f"Model returned perspective_slug {parsed.perspective_slug!r}; "
-                f"expected {perspective_slug!r}"
+        # This call scored exactly one perspective (perspective_slug), and the
+        # score is always persisted under it below. The model's echoed slug is
+        # only a sanity check; some models won't reproduce it verbatim when a
+        # perspective's display_name diverges from its slug. Persist the score
+        # under the requested perspective rather than discarding valid work —
+        # just log the discrepancy for observability.
+        if got_slug != perspective_slug.strip() and log_callback:
+            log_callback(
+                "warning",
+                f"Slug mismatch: model returned {parsed.perspective_slug!r}, "
+                f"normalized to {got_slug!r}, expected {perspective_slug!r} — "
+                f"persisting under {perspective_slug!r}",
             )
-            return False
         return True
 
     def persist(parsed_bundle: tuple, provider: str, model_used: str) -> None:
@@ -157,8 +156,6 @@ def _run_score_persist(
         persist=persist,
     )
     if outcome.status == "failed" and outcome.reason == "invalid result":
-        if "msg" in reject_reason:
-            return VisionOpOutcome(status="failed", reason=reject_reason["msg"])
         return VisionOpOutcome(
             status="failed",
             reason="model returned empty or invalid score response",

--- a/lightroom_tagger/core/test_scoring_service.py
+++ b/lightroom_tagger/core/test_scoring_service.py
@@ -335,7 +335,15 @@ def test_score_image_skips_video_without_calling_provider(tmp_path) -> None:
     assert rows == []
 
 
-def test_score_image_fails_with_specific_reason_on_slug_mismatch(tmp_path) -> None:
+def test_score_image_persists_under_requested_slug_on_slug_mismatch(tmp_path) -> None:
+    """A model that echoes a non-matching perspective_slug must not lose the score.
+
+    The call scores exactly one perspective (``expected_slug``) and always persists
+    under it; the echoed slug is only a sanity check. Regression guard for the
+    scoring job silently discarding every score for a perspective whose
+    display_name diverges from its slug (e.g. intensity-suggestion /
+    "Interpretive & Human Charge").
+    """
     conn = init_database(str(tmp_path / "library.db"))
     insert_perspective(
         conn,
@@ -360,6 +368,8 @@ def test_score_image_fails_with_specific_reason_on_slug_mismatch(tmp_path) -> No
     mock_dispatcher = MagicMock()
     mock_dispatcher.call_with_fallback.return_value = (raw_json, "ollama", "vision-model")
 
+    logs: list[tuple[str, str]] = []
+
     with ExitStack() as stack:
         for p in _scoring_patches(mock_registry=mock_registry, mock_dispatcher=mock_dispatcher):
             stack.enter_context(p)
@@ -371,14 +381,22 @@ def test_score_image_fails_with_specific_reason_on_slug_mismatch(tmp_path) -> No
             force=True,
             provider_id="ollama",
             model="vision-model",
-            log_callback=None,
+            log_callback=lambda level, msg: logs.append((level, msg)),
         )
 
-    assert outcome.status == "failed"
-    assert outcome.wrote is False
-    assert "wrong_slug" in (outcome.reason or "")
-    assert "expected_slug" in (outcome.reason or "")
-    assert get_current_scores_for_image(conn, "2020-01-01_slug.jpg", "catalog") == []
+    # The score is kept, persisted under the requested perspective.
+    assert outcome.reason is None
+    assert outcome.wrote is True
+    rows = get_current_scores_for_image(conn, "2020-01-01_slug.jpg", "catalog")
+    assert len(rows) == 1
+    assert rows[0]["perspective_slug"] == "expected_slug"
+    assert rows[0]["score"] == 6
+    assert rows[0]["is_current"] == 1
+    # The discrepancy is still surfaced as a warning for observability.
+    assert any(
+        level == "warning" and "wrong_slug" in msg and "expected_slug" in msg
+        for level, msg in logs
+    )
 
 
 def test_score_image_fails_on_generic_invalid_model_response(tmp_path) -> None:


### PR DESCRIPTION
## Problem

A `batch_score` run (`ollama:kimi-k2.6:cloud`, catalog, 4 perspectives) silently produced **zero scores** for the `intensity-suggestion` perspective — 63/63 attempts logged `Slug mismatch … — skipping`. Diagnosed from job `07a50a2e-…` logs + `library.db`.

## Root cause

The scoring prompt (`prompt_builder.py:88-113`) asks the model to return `perspective_slug` "verbatim" and renders the header as `{display_name} ({slug})`. After the local **6→4 perspective merge**, `intensity-suggestion`'s `display_name` is **"Interpretive & Human Charge"** — semantically disjoint from the slug (shares no words). Kimi echoed a display-name-derived slug (`interpretive-human-charge`, `interpretive_and_human_charge`, …). `accept_result` (`scoring_service.py:108`) then **rejected** the result on the mismatch and discarded the otherwise-valid score.

The echoed slug is **redundant**: each call scores exactly one perspective (`perspective_slug`) and always persists under it (`scoring_service.py:142`). The strict echo-check was defensive theater that destroyed valid work.

This also removes a **latent** failure for `environmental-context-legibility` (display_name "Depth & Environmental Context" also diverges from its slug — it only survived by luck of the model echoing the right token).

> Note: `compositional-cleanliness` showing zero in that run was **not** a bug — it already had 648 current rows and was correctly skipped by `force=false`.

## Change

- `scoring_service.py` — on slug mismatch, **persist under the requested perspective** and log a `warning` for observability instead of rejecting. Drops the now-dead `reject_reason` plumbing.
- `test_scoring_service.py` — flips the old `..._fails_with_specific_reason_on_slug_mismatch` test to `..._persists_under_requested_slug_on_slug_mismatch`: asserts the row lands under `expected_slug` with the correct score **and** that the discrepancy is still surfaced as a warning.

## Verification
- `test_scoring_service.py` + `test_vision_op.py` + `test_database_scores.py`: **33 passed**. Ruff clean.
- Not touched: the normalizer and prompt wording (optional follow-ups to reduce warning noise — see the diagnosis). This PR is the minimal robust fix.

After merge: re-running the `batch_score` job will populate `intensity-suggestion` (and is now immune to display_name/slug divergence for any perspective).

🤖 Generated with [Claude Code](https://claude.com/claude-code)