### PR TITLE
fix(config): ignore unknown config.yaml keys instead of crashing

### DIFF
--- a/lightroom_tagger/core/config.py
+++ b/lightroom_tagger/core/config.py
@@ -1,11 +1,14 @@
+import logging
 import os
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 from pathlib import Path
 
 import yaml
 from dotenv import load_dotenv
 
 load_dotenv()
+
+logger = logging.getLogger(__name__)
 
 _CONFIG_MODULE_DIR = Path(__file__).resolve().parent
 
@@ -109,6 +112,22 @@ def load_config(config_path: str | None = None) -> Config:
     for key, value in defaults.items():
         if key not in data:
             data[key] = value
+
+    # A config file outlives the code that read it: retiring a capability leaves
+    # its keys behind in every existing config.yaml. Passing those straight into
+    # Config(**data) raises TypeError from deep inside the dataclass constructor,
+    # which surfaces as an opaque 500 in the visualizer rather than anything the
+    # owner can act on. Drop unknown keys — but log them, so a typo like
+    # ``vison_model`` is visible instead of silently falling back to the default.
+    known_fields = {f.name for f in fields(Config)}
+    unknown = sorted(set(data) - known_fields)
+    if unknown:
+        logger.warning(
+            "Ignoring unknown config key(s) in %s: %s",
+            config_file,
+            ", ".join(unknown),
+        )
+        data = {k: v for k, v in data.items() if k in known_fields}
 
     return Config(**data)
 

--- a/lightroom_tagger/core/test_config.py
+++ b/lightroom_tagger/core/test_config.py
@@ -65,6 +65,44 @@ class TestLoadConfig(unittest.TestCase):
         self.assertEqual(config.catalog_path, "/test/catalog")
         self.assertEqual(config.db_path, "/test/db")
 
+    @patch(
+        "lightroom_tagger.core.config.open",
+        new_callable=mock_open,
+        read_data="catalog_path: /test/catalog\nvision_batch_size: 10\nvision_batch_threshold: 5\n",
+    )
+    @patch("lightroom_tagger.core.config.Path.exists", return_value=True)
+    @patch("lightroom_tagger.core.config.load_dotenv")
+    @patch.dict("os.environ", {}, clear=True)
+    def test_load_config_ignores_unknown_keys(self, mock_dotenv, mock_exists, mock_file):
+        """Keys left behind by a retired capability must not crash startup.
+
+        ``vision_batch_size`` / ``vision_batch_threshold`` are real debris from the
+        parked batch-vision work: they sat in a live config.yaml and took the whole
+        app down with ``TypeError: Config.__init__() got an unexpected keyword
+        argument``.
+        """
+        with self.assertLogs("lightroom_tagger.core.config", level="WARNING") as logs:
+            config = load_config("config.yaml")
+        self.assertEqual(config.catalog_path, "/test/catalog")
+        joined = "\n".join(logs.output)
+        self.assertIn("vision_batch_size", joined)
+        self.assertIn("vision_batch_threshold", joined)
+
+    @patch(
+        "lightroom_tagger.core.config.open",
+        new_callable=mock_open,
+        read_data="catalog_path: /test/catalog\nvison_model: typo-model\n",
+    )
+    @patch("lightroom_tagger.core.config.Path.exists", return_value=True)
+    @patch("lightroom_tagger.core.config.load_dotenv")
+    @patch.dict("os.environ", {}, clear=True)
+    def test_load_config_warns_on_misspelled_key(self, mock_dotenv, mock_exists, mock_file):
+        """A typo must be visible, not silently swallowed into the default."""
+        with self.assertLogs("lightroom_tagger.core.config", level="WARNING") as logs:
+            config = load_config("config.yaml")
+        self.assertIn("vison_model", "\n".join(logs.output))
+        self.assertEqual(config.vision_model, "gemma3:27b")
+
     @patch("lightroom_tagger.core.config.open", new_callable=mock_open, read_data="catalog_path: /file/catalog\ndb_path: /file/db\n")
     @patch("lightroom_tagger.core.config.Path.exists", return_value=True)
     @patch("lightroom_tagger.core.config.load_dotenv")


### PR DESCRIPTION
## Problem

`load_config` builds a dict from YAML + env + defaults and passes it straight into `Config(**data)`. Any key the dataclass doesn't declare raises `TypeError: Config.__init__() got an unexpected keyword argument ...` from inside the constructor — which surfaces in the visualizer as an opaque 500 with no indication of which key is at fault.

Not hypothetical. A live `config.yaml` carried:

```yaml
vision_batch_size: 10
vision_batch_threshold: 5
```

Neither key exists anywhere in the codebase — they are debris from the batch-vision work parked with the Instagram removal. They took down the frontend and 11 local tests in `test_scoring_service.py` / `test_description_service.py`.

## Fix

Filter `data` to the dataclass's declared fields before constructing, and log the dropped keys at WARNING.

**Why warn rather than silently drop:** silence would turn a typo like `vison_model` into an invisible fallback to the default — a worse failure than crashing, because nothing tells you your setting is being ignored. Both behaviours are pinned by tests.

## Why this is worth hardening, not just deleting the two keys

A config file outlives the code that reads it. Retiring a capability leaves its keys behind in every existing `config.yaml` on disk, and #218 has retired three capabilities. Every future removal sets the same trap, and the person who hits it is a fresh user with no way to map the `TypeError` back to a line in their config.

## Testing

- `test_load_config_ignores_unknown_keys` — the real `vision_batch_size` / `vision_batch_threshold` case loads cleanly and names both keys in the warning.
- `test_load_config_warns_on_misspelled_key` — `vison_model` warns *and* falls back to the declared default.
- Full library suite: 564 passed. The one failure (`test_api_modules_do_not_import_sibling_api_modules`) is pre-existing on master — verified by stashing this change — and is one of the latent architecture violations tracked by #169.
