### PR TITLE
ci: run the contract drift gate on lightroom_tagger changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'apps/visualizer/**'
+      - 'lightroom_tagger/**'
       - 'docs/adr/**'
 
 jobs:


### PR DESCRIPTION
Adds `lightroom_tagger/**` to the workflow's `pull_request` path filter.

A library-only PR previously matched nothing in the filter and ran **zero** checks. That is how PR #258 shipped the `search_by_keyword` regression tracked as #261. It also meant #269's newly-gated core guardrails never fired on the changes most likely to break them.

Pushed from a local clone rather than by Sandcastle — GitHub rejects an App push touching `.github/workflows/**`, and rejects the whole branch with it.

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)