### PR TITLE
fix(search): let the CLI search short keywords again

### DIFF
--- a/lightroom_tagger/core/database/catalog.py
+++ b/lightroom_tagger/core/database/catalog.py
@@ -184,9 +184,10 @@ def search_by_keyword(db: sqlite3.Connection, keyword: str) -> list[dict]:
     )
     bindings: list = [pattern, pattern, pattern, pattern]
 
-    match_str, fts_err = build_description_fts_query(keyword)
-    if fts_err:
-        raise ValueError(fts_err)
+    # The builder's short-query rule is the web API's (it answers with HTTP 400);
+    # here it only means "this term has no FTS half", so the Lightroom-metadata
+    # search still runs and a one-character keyword stays a legitimate query (#261).
+    match_str, _fts_err = build_description_fts_query(keyword)
     if match_str is not None:
         where = f"({where}) OR key IN ({DESCRIPTION_FTS_KEY_SUBQUERY})"
         bindings.append(match_str)

--- a/lightroom_tagger/core/test_database_catalog.py
+++ b/lightroom_tagger/core/test_database_catalog.py
@@ -270,7 +270,30 @@ class TestSearchByKeyword(unittest.TestCase):
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]['filename'], 'both.jpg')
 
-    def test_malformed_query_raises(self):
-        with self.assertRaises(ValueError) as ctx:
-            search_by_keyword(self.db, 'a')
-        self.assertIn('at least 2 characters', str(ctx.exception))
+    def test_short_keyword_falls_back_to_lightroom_metadata(self):
+        """One character is too short for FTS but fine for a LIKE over metadata (#261)."""
+        store_image(self.db, {
+            'date_taken': '2024-01-15',
+            'filename': 'plain.jpg',
+            'keywords': ['sunset'],
+        })
+        store_image(self.db, {
+            'date_taken': '2024-01-16',
+            'filename': 'other.jpg',
+            'keywords': ['portrait'],
+        })
+        # 'u' appears in sunset but not in portrait/other.jpg.
+        results = search_by_keyword(self.db, 'u')
+        self.assertEqual([r['filename'] for r in results], ['plain.jpg'])
+
+    def test_short_keyword_ignores_descriptions(self):
+        """The FTS half is skipped, not silently widened, for a sub-minimum term."""
+        store_image(self.db, {'date_taken': '2024-01-15', 'filename': 'described.jpg'})
+        store_image_description(self.db, {
+            'image_key': '2024-01-15_described.jpg',
+            'image_type': 'catalog',
+            'summary': 'A quiet dawn',
+            'model_used': 'test',
+        })
+        # 'q' is only in the description, which FTS cannot be asked about here.
+        self.assertEqual(search_by_keyword(self.db, 'q'), [])


### PR DESCRIPTION
`lightroom-tagger search --keyword "a"` has failed since #258 with `Error: description_search must be at least 2 characters` — an API parameter name at a CLI prompt, from a rule that belongs to only one half of the query.

`search_by_keyword` searches Lightroom metadata **and** the description FTS index. The FTS builder's two-character minimum means the term has no FTS half; it says nothing about the metadata `LIKE`, which was answering these queries before #258. Raising on it rejected the whole search.

Now the FTS half is skipped and the metadata half runs alone. No error remains for the CLI to emit, so the API-worded message is gone with it. `catalog_query_filters.py` — the web API path — still honours the error and returns 400; that rule is unchanged and stays where it belongs.

Two tests replace the one that asserted the raise: a short keyword matches metadata, and it does *not* reach descriptions (the FTS half is skipped, not silently widened).

Library suite: 573 passed.

**This is the first library-only PR to run CI**, via the path filter added in #272.

Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)