### PR TITLE
fix(descriptions): retire the previous terms when a description is regenerated

### DIFF
--- a/lightroom_tagger/core/database/descriptions.py
+++ b/lightroom_tagger/core/database/descriptions.py
@@ -83,6 +83,45 @@ def _visual_attr_json(value) -> str | None:
     return None
 
 
+def _fts_is_external_content(db: sqlite3.Connection) -> bool:
+    """Whether ``image_descriptions_fts`` is an external-content FTS5 table.
+
+    Both forms are in the wild and they need opposite removal statements. The
+    catalogs in use carry ``content='image_descriptions'``, while
+    :func:`_migrate_image_descriptions_fts` builds a standalone table for fresh
+    databases and only re-runs below ``user_version`` 3 — so an existing catalog
+    keeps whichever form it was created with.
+    """
+    row = db.execute(
+        "SELECT sql FROM sqlite_master WHERE name = 'image_descriptions_fts'"
+    ).fetchone()
+    return bool(row) and re.search(r"\bcontent\s*=", row["sql"] or "") is not None
+
+
+def _remove_description_fts_row(
+    db: sqlite3.Connection, rowid: int, indexed_document: str
+) -> None:
+    """Drop *rowid* from the FTS index, given the document text that was indexed.
+
+    An external-content table must go through FTS5's ``'delete'`` command. The
+    obvious ``DELETE ... WHERE rowid = ?`` makes FTS5 re-tokenize whatever the
+    content table holds *now*, which raises ``database disk image is malformed``
+    against an empty index and silently strips the wrong terms against a
+    populated one — leaving the previous description searchable for ever while
+    still passing an ``integrity-check``. A standalone table is the mirror
+    image: it rejects the ``'delete'`` command and needs the plain statement.
+    """
+    if _fts_is_external_content(db):
+        db.execute(
+            "INSERT INTO image_descriptions_fts"
+            "(image_descriptions_fts, rowid, description_search_document) "
+            "VALUES('delete', ?, ?)",
+            (rowid, indexed_document),
+        )
+    else:
+        db.execute("DELETE FROM image_descriptions_fts WHERE rowid = ?", (rowid,))
+
+
 def init_image_descriptions_table(db: sqlite3.Connection):
     """No-op: table is created in init_database."""
     pass
@@ -112,6 +151,15 @@ def store_image_description(db: sqlite3.Connection, record: dict) -> str:
         description_search_document = None
 
     with library_write(db):
+        # Read before the upsert: removing the old index entry needs the text
+        # that was indexed, and only a previous catalog write with a non-empty
+        # document indexed anything at all.
+        previous = db.execute(
+            "SELECT rowid, image_type, description_search_document "
+            "FROM image_descriptions WHERE image_key = ?",
+            (image_key,),
+        ).fetchone()
+
         db.execute("""
             INSERT INTO image_descriptions
                 (image_key, image_type, summary, composition,
@@ -143,7 +191,10 @@ def store_image_description(db: sqlite3.Connection, record: dict) -> str:
         ).fetchone()
         if row is not None:
             rowid = row["rowid"]
-            db.execute("DELETE FROM image_descriptions_fts WHERE rowid = ?", (rowid,))
+            if previous is not None and previous["image_type"] == "catalog":
+                indexed = previous["description_search_document"]
+                if indexed and str(indexed).strip():
+                    _remove_description_fts_row(db, previous["rowid"], indexed)
             doc = description_search_document
             if image_type == "catalog" and doc and str(doc).strip():
                 db.execute(

--- a/lightroom_tagger/core/test_database_descriptions.py
+++ b/lightroom_tagger/core/test_database_descriptions.py
@@ -194,6 +194,86 @@ class TestImageDescriptions(unittest.TestCase):
         self.assertEqual(n, 0)
 
 
+    def test_store_image_description_retires_previous_fts_terms(self):
+        key = "fts-regen-1"
+        store_image_description(self.db, {
+            "image_key": key, "image_type": "catalog",
+            "summary": "a red bicycle", "subjects": ["bicycle"], "model_used": "m",
+        })
+        store_image_description(self.db, {
+            "image_key": key, "image_type": "catalog",
+            "summary": "a blue canoe", "subjects": ["canoe"], "model_used": "m",
+        })
+
+        def hits(term):
+            return self.db.execute(
+                "SELECT COUNT(*) AS n FROM image_descriptions_fts "
+                "WHERE image_descriptions_fts MATCH ?",
+                (term,),
+            ).fetchone()["n"]
+
+        self.assertEqual(hits("bicycle"), 0, "old description is still searchable")
+        self.assertEqual(hits("canoe"), 1)
+
+
+class TestExternalContentDescriptionFts(unittest.TestCase):
+    """``store_image_description`` against the external-content FTS5 form.
+
+    Catalogs in the field carry ``content='image_descriptions'`` rather than the
+    standalone table :func:`init_database` builds, and the two need opposite
+    removal statements. ``init_database`` cannot reach this shape — the FTS
+    migration is gated below ``user_version`` 3 — so the table is rebuilt here.
+    Without this the external-content path has no coverage at all, which is how
+    it came to raise ``database disk image is malformed`` on a first write.
+    """
+
+    def setUp(self):
+        fd, self.temp_db_path = tempfile.mkstemp(suffix='.db')
+        os.close(fd)
+        self.db = init_database(self.temp_db_path)
+        self.db.execute("DROP TABLE IF EXISTS image_descriptions_fts")
+        self.db.execute(
+            "CREATE VIRTUAL TABLE image_descriptions_fts USING fts5("
+            "description_search_document, tokenize='porter unicode61', "
+            "content='image_descriptions', content_rowid='rowid')"
+        )
+        self.db.commit()
+
+    def tearDown(self):
+        self.db.close()
+        os.unlink(self.temp_db_path)
+
+    def _hits(self, term):
+        return self.db.execute(
+            "SELECT COUNT(*) AS n FROM image_descriptions_fts "
+            "WHERE image_descriptions_fts MATCH ?",
+            (term,),
+        ).fetchone()["n"]
+
+    def test_first_write_indexes_without_corrupting(self):
+        store_image_description(self.db, {
+            "image_key": "ext-1", "image_type": "catalog",
+            "summary": "a red bicycle", "subjects": ["bicycle"], "model_used": "m",
+        })
+        self.assertEqual(self._hits("bicycle"), 1)
+
+    def test_regenerate_retires_previous_terms(self):
+        for summary, subject in (("a red bicycle", "bicycle"), ("a blue canoe", "canoe")):
+            store_image_description(self.db, {
+                "image_key": "ext-2", "image_type": "catalog",
+                "summary": summary, "subjects": [subject], "model_used": "m",
+            })
+
+        self.assertEqual(self._hits("bicycle"), 0, "old description is still searchable")
+        self.assertEqual(self._hits("canoe"), 1)
+        # A plain DELETE leaves the index self-consistent while being wrong, so
+        # the term assertions above are the real check; this only catches damage.
+        self.db.execute(
+            "INSERT INTO image_descriptions_fts(image_descriptions_fts) "
+            "VALUES('integrity-check')"
+        )
+
+
 class TestBuildDescriptionFtsQuery(unittest.TestCase):
     """``build_description_fts_query`` — AND tokens, NLS-02 sanitization."""
 


### PR DESCRIPTION
## The bug

Re-describing an image leaves the **old** description searchable for ever. `description_search` on the Images tab and the CLI keyword search both keep matching text the image no longer has.

`image_descriptions_fts` is an **external-content** FTS5 table (`content='image_descriptions'`) in the catalogs actually in use. For that form, `DELETE FROM image_descriptions_fts WHERE rowid = ?` does not remove what was indexed — FTS5 re-reads the content row to decide which terms to drop, and by then the row has already been upserted to the new text. So the delete strips the *new* terms and leaves the *old* ones behind.

Nothing looks wrong afterwards: the index stays self-consistent and `integrity-check` passes.

There is a sharper edge on an **empty** external-content index, where the same statement raises `database disk image is malformed` outright. A fresh catalog on this schema cannot store its first description at all.

## Why it survived

The two FTS forms need opposite statements, and only one of them was ever tested.

| Form | Where it comes from | Correct removal |
|---|---|---|
| external-content | catalogs in the field | FTS5 `'delete'` command |
| standalone | `_migrate_image_descriptions_fts`, fresh DBs | plain `DELETE` |

Every existing test builds its database with `init_database`, which produces the **standalone** table — the one the old statement happens to be right for. The external-content path had no coverage.

The two shapes coexist permanently: the migration is gated below `user_version` 3, so an existing catalog never converts. (The production catalog here is at `user_version` 8.)

## The fix

Removal goes through FTS5's `'delete'` command carrying the text that was actually indexed, read before the upsert and issued only when the previous write indexed something. The table form is detected from `sqlite_master`, since the standalone form rejects that command.

## Verification

- `TestExternalContentDescriptionFts` covers the previously untested form; it rebuilds the table in that shape because `init_database` cannot reach it. Confirmed to fail without the fix.
- A regression test on the standalone form pins the same behaviour.
- Verified directly against the production schema: first write and regenerate both succeed, stale terms gone, `integrity-check` clean, on **both** table forms.
- Full suites pass: 644 library tests, 532 visualizer backend tests.

## Note

Found while porting this function to TypeScript on `ts-backend-migration`, where the faithful port inherited the bug. The TS side is fixed in `563db0b`.